### PR TITLE
Bump version to 0.0.1 for update system testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 license = "MIT"
 

--- a/cli-update-policy.json
+++ b/cli-update-policy.json
@@ -1,5 +1,5 @@
 {
   "policy": "nudge",
-  "minimum_version": "0.1.0",
+  "minimum_version": "0.0.1",
   "message": ""
 }


### PR DESCRIPTION
Bumps workspace version to 0.0.1 and policy minimum_version to match.

This is temporary for testing the update pipeline. Will bump to 0.1.0 for the real public launch after testing is complete.