### PR TITLE
Fix hardcoded version in update tests

### DIFF
--- a/coast-update/src/version.rs
+++ b/coast-update/src/version.rs
@@ -32,13 +32,14 @@ mod tests {
     #[test]
     fn test_current_version_parses() {
         let v = current_version().unwrap();
-        // Should match the workspace version
-        assert_eq!(v, Version::new(0, 1, 0));
+        // Just verify it parses as valid semver
+        assert!(v.major < 100, "version should be reasonable");
     }
 
     #[test]
     fn test_current_version_const() {
-        assert_eq!(CURRENT_VERSION, "0.1.0");
+        // Verify CURRENT_VERSION is valid semver, don't pin to a specific value
+        assert!(parse_version(CURRENT_VERSION).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Version tests should verify semver parses correctly, not assert a specific version number. Broken by the 0.0.1 bump.