### PR TITLE
Bump version to 0.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
Version bump for update system testing. DO NOT upgrade locally — keep 0.0.1 installed to test nudge/required/auto policies.