### PR TITLE
Fix update policy to respect configured tier

### DIFF
--- a/.github/workflows/update-policy.yml
+++ b/.github/workflows/update-policy.yml
@@ -28,6 +28,18 @@ jobs:
         with:
           token: ${{ secrets.POLICY_PUSH_TOKEN }}
 
+      - name: Validate minimum_version exists as a release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ github.event.inputs.minimum_version }}"
+          if ! gh release view "$VERSION" > /dev/null 2>&1; then
+            echo "::error::Release $VERSION does not exist. Available releases:"
+            gh release list --limit 20
+            exit 1
+          fi
+          echo "Validated: release $VERSION exists"
+
       - name: Update policy file
         run: |
           cat > cli-update-policy.json << EOF


### PR DESCRIPTION
## Summary
- **Policy tier bug**: `evaluate_policy()` hardcoded `PolicyAction::Required` when the current version was below `minimum_version`, ignoring the configured tier. A `nudge` policy now correctly nudges instead of blocking.
- **Workflow validation**: The update-policy workflow now validates that `minimum_version` corresponds to an existing GitHub release before committing, preventing misconfiguration.

## Test plan
- [x] All 48 `coast-update` tests pass (including 3 new/updated tests)
- [ ] Build locally and verify `nudge` policy with a below-minimum version shows a post-command message instead of blocking
- [ ] Trigger the update-policy workflow with a non-existent version and confirm it fails with available releases listed