### PR TITLE
Fix release workflow to set version from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set version from git tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -83,6 +88,11 @@ jobs:
             use_cross: true
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set version from git tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- The release workflow never bumped the workspace `Cargo.toml` version, so `CARGO_PKG_VERSION` (and `coast --version`) always reported `0.1.0` regardless of the release tag.
- Both macOS and Linux build jobs now patch the workspace version from the git tag before compiling.

## Test plan
- [ ] Tag a new release (e.g. v0.1.3) and verify the installed binary reports the correct version via `coast --version`