### PR TITLE
[dh] feat: add `coast skills-prompt` command for agent self-setup

### DIFF
--- a/coast-cli/src/commands/mod.rs
+++ b/coast-cli/src/commands/mod.rs
@@ -30,6 +30,7 @@ pub mod run;
 pub mod search_docs;
 pub mod secret;
 pub mod shared;
+pub mod skills_prompt;
 pub mod start;
 pub mod stop;
 pub mod ui;

--- a/coast-cli/src/commands/skills_prompt.rs
+++ b/coast-cli/src/commands/skills_prompt.rs
@@ -1,0 +1,51 @@
+/// `coast skills-prompt` — print the Coast runtime skills prompt for AI coding agents.
+///
+/// This command is standalone and does not require the daemon to be running.
+/// The prompt text is compiled into the binary via `include_str!()`.
+use anyhow::Result;
+use clap::Args;
+
+const PROMPT: &str = include_str!("../../../docs/skills_prompt.txt");
+
+/// Arguments for `coast skills-prompt`.
+#[derive(Debug, Args)]
+pub struct SkillsPromptArgs {}
+
+/// Print the skills prompt to stdout.
+pub async fn execute(_args: &SkillsPromptArgs) -> Result<()> {
+    print!("{PROMPT}");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: SkillsPromptArgs,
+    }
+
+    #[test]
+    fn test_skills_prompt_args_parse() {
+        let cli = TestCli::try_parse_from(["test"]).unwrap();
+        let _ = cli.args;
+    }
+
+    #[test]
+    fn test_prompt_text_is_non_empty() {
+        assert!(
+            !PROMPT.is_empty(),
+            "skills_prompt.txt should be compiled into the binary"
+        );
+    }
+
+    #[test]
+    fn test_prompt_text_contains_key_commands() {
+        assert!(PROMPT.contains("coast lookup"));
+        assert!(PROMPT.contains("coast exec"));
+        assert!(PROMPT.contains("coast logs"));
+    }
+}

--- a/coast-cli/src/lib.rs
+++ b/coast-cli/src/lib.rs
@@ -55,6 +55,9 @@ pub enum Commands {
     /// Print the Coastfile installation prompt for AI coding agents.
     #[command(name = "installation-prompt")]
     InstallationPrompt(commands::installation_prompt::InstallationPromptArgs),
+    /// Print the Coast runtime skills prompt for AI coding agents.
+    #[command(name = "skills-prompt")]
+    SkillsPrompt(commands::skills_prompt::SkillsPromptArgs),
 
     // --- Project-explicit commands (project as positional arg or self-resolved) ---
     /// Build a coast image from a Coastfile.
@@ -242,6 +245,7 @@ async fn dispatch(cli: Cli) -> Result<()> {
         Commands::Docs(args) => commands::docs::execute(&args).await,
         Commands::SearchDocs(args) => commands::search_docs::execute(&args).await,
         Commands::InstallationPrompt(args) => commands::installation_prompt::execute(&args).await,
+        Commands::SkillsPrompt(args) => commands::skills_prompt::execute(&args).await,
 
         // --- Project-explicit commands ---
         Commands::Build(args) => commands::build::execute(&args).await,
@@ -592,6 +596,12 @@ mod tests {
     fn test_cli_installation_prompt_subcommand() {
         let cli = Cli::try_parse_from(["coast", "installation-prompt"]).unwrap();
         assert!(matches!(cli.command, Commands::InstallationPrompt(_)));
+    }
+
+    #[test]
+    fn test_cli_skills_prompt_subcommand() {
+        let cli = Cli::try_parse_from(["coast", "skills-prompt"]).unwrap();
+        assert!(matches!(cli.command, Commands::SkillsPrompt(_)));
     }
 
     #[test]

--- a/docs/SKILLS_FOR_HOST_AGENTS.md
+++ b/docs/SKILLS_FOR_HOST_AGENTS.md
@@ -85,23 +85,29 @@ find the relevant documentation.
 
 ## Adding the Skill to Your Agent
 
-How you add this depends on your agent:
+The fastest way is to let the agent set itself up. Run one of these from your project directory:
 
-### Claude Code
+```sh
+# Claude Code
+claude -p "$(coast skills-prompt)"
 
-Add the skill text to your project's `CLAUDE.md` file, or create a dedicated section for it.
+# Codex
+codex "$(coast skills-prompt)"
 
-### Codex
+# Cursor (from terminal)
+cursor --chat "$(coast skills-prompt)"
+```
 
-Add the skill text to your project's `AGENTS.md` file.
+This gives the agent the skill text and instructions to write it to its own config file (`CLAUDE.md`, `AGENTS.md`, `.cursor/rules/coast.md`, etc.).
 
-### Cursor
+### Manual setup
 
-Create a rules file at `.cursor/rules/coast.mdc` (or `.cursor/rules/coast.md`) in your project root and paste the skill text above.
+If you prefer to add the skill yourself:
 
-### Other agents
-
-Most agents support some form of project-level prompt or rules file. Paste the skill text into whatever your agent reads at session start.
+- **Claude Code:** Add the skill text to your project's `CLAUDE.md` file.
+- **Codex:** Add the skill text to your project's `AGENTS.md` file.
+- **Cursor:** Create `.cursor/rules/coast.md` in your project root and paste the skill text.
+- **Other agents:** Paste the skill text into whatever project-level prompt or rules file your agent reads at startup.
 
 ## Further Reading
 

--- a/docs/skills_prompt.txt
+++ b/docs/skills_prompt.txt
@@ -1,0 +1,97 @@
+You are setting up Coast runtime skills for this project. Coast (containerized host) runs isolated development environments using Docker-in-Docker containers. This project already has a Coastfile — your job is to add the Coast runtime skill to your agent configuration so you can interact with the running environment.
+
+=== WHAT TO DO ===
+
+1. Determine which agent configuration file to use based on your environment:
+   - Claude Code: add to `CLAUDE.md` in the project root (create if it doesn't exist)
+   - Codex: add to `AGENTS.md` in the project root (create if it doesn't exist)
+   - Cursor: add to `.cursor/rules/coast.md` in the project root (create directories if needed)
+   - Other agents: add to whatever project-level prompt or rules file your agent reads at startup
+
+2. Add the following skill text to that file under a "Coast Runtime" section. If the file already exists, append this as a new section — do not overwrite existing content.
+
+=== SKILL TEXT (add this to the agent config file) ===
+
+# Coast Runtime
+
+This project uses Coasts (containerized host) for isolated development environments.
+Your code edits are automatically visible inside the running Coast — the filesystem
+is shared between the host and the container.
+
+## Orientation
+
+Before running any runtime commands, discover which Coast instance matches your
+current working directory:
+
+```
+coast lookup
+```
+
+This prints the instance name, ports, URLs, and example commands. Use the instance
+name from the output for all subsequent commands.
+
+If you need deeper context on how Coasts work, read these docs:
+
+```
+coast docs --path concepts_and_terminology/LOOKUP.md
+coast docs --path concepts_and_terminology/FILESYSTEM.md
+coast docs --path concepts_and_terminology/EXEC_AND_DOCKER.md
+coast docs --path concepts_and_terminology/LOGS.md
+```
+
+## Running Commands
+
+Use `coast exec` to run commands inside the Coast. The shell starts at the workspace
+root (where the Coastfile is). cd to your target directory first:
+
+```
+coast exec <instance> -- sh -c "cd <dir> && <command>"
+```
+
+Examples:
+
+```
+coast exec dev-1 -- sh -c "cd src && npm test"
+coast exec dev-1 -- sh -c "cd backend && go test ./..."
+coast exec dev-1 -- sh -c "cd apps/web && npx playwright test"
+```
+
+## Runtime Feedback
+
+Check service status:
+
+```
+coast ps <instance>
+```
+
+Read service logs:
+
+```
+coast logs <instance> --service <service>
+coast logs <instance> --service <service> --tail 50
+```
+
+## Troubleshooting
+
+If you encounter errors or unfamiliar behavior, search the Coast docs:
+
+```
+coast search-docs "error message or description"
+```
+
+This uses semantic search — describe the problem in natural language and it will
+find the relevant documentation.
+
+## Rules
+
+- Always run `coast lookup` before your first runtime command in a session.
+- Do not run services directly on the host. Use `coast exec` for all runtime tasks.
+- File edits on the host are instantly visible inside the Coast. You do not need
+  to copy files or rebuild after editing.
+- If `coast lookup` returns no instances, the Coast may not be running. Suggest
+  `coast run dev-1` or check `coast ls` for the project state.
+
+=== END SKILL TEXT ===
+
+3. After writing the file, verify the Coastfile exists in this project by running `ls Coastfile`.
+4. If a Coast is already running, run `coast lookup` to confirm the skill works. If no Coast is running, tell the user they can start one with `coast run dev-1`.


### PR DESCRIPTION
Adds a new CLI command that outputs a prompt instructing AI agents to write the Coast runtime skills into their own config file (CLAUDE.md, AGENTS.md, .cursor/rules/, etc.).

Usage:
  claude -p "$(coast skills-prompt)"
  codex "$(coast skills-prompt)"
  cursor --chat "$(coast skills-prompt)"

Also updates SKILLS_FOR_HOST_AGENTS.md to document this pattern.