### PR TITLE
Restart daemon after CLI update

### DIFF
--- a/coast-cli/src/commands/daemon.rs
+++ b/coast-cli/src/commands/daemon.rs
@@ -284,14 +284,21 @@ async fn execute_start() -> Result<()> {
     }
 }
 
-async fn execute_restart(force: bool) -> Result<()> {
+async fn execute_restart(_force: bool) -> Result<()> {
+    restart_daemon_if_running().await
+}
+
+/// Restart the daemon if it's currently running. Used after updates
+/// to pick up the new binary.
+pub async fn restart_daemon_if_running() -> Result<()> {
     let status = daemon_status()?;
 
     if status.running {
-        execute_kill(force).await?;
+        execute_kill(false).await?;
+        execute_start().await?;
     }
 
-    execute_start().await
+    Ok(())
 }
 
 const TAIL_LINES: usize = 20;

--- a/coast-cli/src/commands/update.rs
+++ b/coast-cli/src/commands/update.rs
@@ -91,6 +91,11 @@ async fn execute_apply() -> Result<()> {
         format!("Updated coast: {} -> {}", current, latest).green()
     );
 
+    // Restart the daemon so it picks up the new binary
+    if let Err(e) = super::daemon::restart_daemon_if_running().await {
+        eprintln!("{} Failed to restart daemon: {e}", "warning:".yellow());
+    }
+
     Ok(())
 }
 

--- a/coast-cli/src/lib.rs
+++ b/coast-cli/src/lib.rs
@@ -362,6 +362,8 @@ pub async fn run() -> Result<()> {
             {
                 Ok(tarball) => match coast_update::updater::apply_update(&tarball) {
                     Ok(()) => {
+                        // Restart daemon so it picks up the new binary
+                        let _ = commands::daemon::restart_daemon_if_running().await;
                         eprintln!(
                             "{} coast updated to {}. Re-run your command.",
                             colored::Colorize::green("done:"),


### PR DESCRIPTION
## Summary
After a successful update (both `coast update apply` and auto-update), the CLI now automatically restarts the daemon so it picks up the new binary. Previously the old `coastd` would keep running until manually restarted.

## Changes
- Added `restart_daemon_if_running()` public function to daemon module
- Called after successful `coast update apply`
- Called after successful auto-update
- Gracefully skips if daemon isn't running
- Warns but doesn't fail if restart errors

## Test plan
- [ ] `coast update apply` → daemon restarts, UI reflects new version immediately
- [ ] Auto-update triggers → daemon restarts before exit
- [ ] If daemon isn't running, no error