### PR TITLE
Add 'Other agents' fallback to docs agent command blocks

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -67,6 +67,10 @@ codex "$(coast installation-prompt)"
 
 # Cursor (from terminal)
 cursor --chat "$(coast installation-prompt)"
+
+# Other agents (manual)
+coast installation-prompt
+# copy the output into your agent's system prompt
 ```
 
 The prompt covers the Coastfile TOML format, volume strategies, secret injection, and all relevant CLI commands. Your agent will analyze your project and generate a Coastfile.

--- a/docs/SKILLS_FOR_HOST_AGENTS.md
+++ b/docs/SKILLS_FOR_HOST_AGENTS.md
@@ -87,7 +87,7 @@ find the relevant documentation.
 
 The fastest way is to let the agent set itself up. Run one of these from your project directory:
 
-```sh
+```bash-emphasis
 # Claude Code
 claude -p "$(coast skills-prompt)"
 
@@ -96,6 +96,10 @@ codex "$(coast skills-prompt)"
 
 # Cursor (from terminal)
 cursor --chat "$(coast skills-prompt)"
+
+# Other agents (manual)
+coast skills-prompt
+# copy the output into your agent's system prompt
 ```
 
 This gives the agent the skill text and instructions to write it to its own config file (`CLAUDE.md`, `AGENTS.md`, `.cursor/rules/coast.md`, etc.).


### PR DESCRIPTION
## Summary
- Adds a manual fallback option (`coast installation-prompt` / `coast skills-prompt` with copy instructions) for agents that don't support direct prompt piping
- Standardizes code fence language to `bash-emphasis` for consistent rendering in both Getting Started and Skills for Host Agents docs

## Files changed
- `docs/GETTING_STARTED.md`
- `docs/SKILLS_FOR_HOST_AGENTS.md`