### PR TITLE
Add parallel frontend CI job, drop redundant merge-to-main run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   COAST_SKIP_UI_BUILD: "1"
 
 jobs:
-  check:
+  rust:
     name: fmt + clippy + test
     runs-on: ubuntu-latest
     steps:
@@ -41,3 +41,43 @@ jobs:
 
       - name: Run tests
         run: cargo test --workspace
+
+  frontend:
+    name: typecheck + lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry & build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: cd coast-guard && npm ci
+
+      - name: Generate TypeScript types from Rust
+        run: cd coast-guard && npm run generate:types
+
+      - name: Generate docs manifest
+        run: cd coast-guard && node scripts/generate-docs.mjs
+
+      - name: Typecheck
+        run: cd coast-guard && npx tsc --noEmit
+
+      - name: Lint
+        run: cd coast-guard && npm run lint


### PR DESCRIPTION
## Summary
- **Drop merge-to-main CI trigger** — tests already run on PRs and release builds from the tag, so the merge run was redundant
- **Add parallel frontend job** — `typecheck + lint` runs alongside `fmt + clippy + test`, catching TS errors on PRs

The frontend job generates TS types from Rust, builds the docs manifest, then runs `tsc --noEmit` and `eslint`.

## Test plan
- [ ] Both jobs appear on this PR's checks and run in parallel