### PR TITLE
Re-exec original command after auto-update

### DIFF
--- a/coast-cli/src/lib.rs
+++ b/coast-cli/src/lib.rs
@@ -374,11 +374,25 @@ pub async fn run() -> Result<()> {
                         // Restart daemon so it picks up the new binary
                         let _ = commands::daemon::restart_daemon_if_running().await;
                         eprintln!(
-                            "{} coast updated to {}. Re-run your command.",
+                            "{} coast updated to {}.",
                             colored::Colorize::green("done:"),
                             latest
                         );
-                        std::process::exit(0);
+                        // Re-exec with the new binary to run the original command
+                        let exe = std::env::current_exe().unwrap_or_default();
+                        let args: Vec<String> = std::env::args().collect();
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::process::CommandExt;
+                            let err = std::process::Command::new(&exe).args(&args[1..]).exec();
+                            eprintln!("Failed to re-exec: {err}");
+                            std::process::exit(1);
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            eprintln!("Re-run your command.");
+                            std::process::exit(0);
+                        }
                     }
                     Err(e) => {
                         eprintln!(


### PR DESCRIPTION
## Summary
Instead of printing "Re-run your command" and exiting after an auto-update, the CLI now exec's the new binary with the original arguments. The user's command runs seamlessly on the updated version.

Before: `coast ui` → auto-update → "Re-run your command." → user has to type `coast ui` again
After: `coast ui` → auto-update → opens the UI automatically

## Test plan
- [ ] Set policy to auto, downgrade, run `coast ui` — should update then open UI without re-prompting