### PR TITLE
Auto-bump CLI policy minimum_version after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,3 +176,30 @@ jobs:
             dist/coast-v*.tar.gz.sha256
           prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-alpha') }}
 
+      - name: Verify release assets are downloadable
+        if: ${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-alpha') }}
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          for PLATFORM in darwin-arm64 darwin-amd64 linux-amd64 linux-arm64; do
+            URL="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/coast-v${VERSION}-${PLATFORM}.tar.gz"
+            echo "Checking ${PLATFORM}..."
+            if ! curl -fsSL --head "$URL" >/dev/null 2>&1; then
+              echo "::error::Asset not downloadable: coast-v${VERSION}-${PLATFORM}.tar.gz"
+              exit 1
+            fi
+          done
+          echo "All assets verified"
+
+      - name: Update CLI policy minimum_version
+        if: ${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-alpha') }}
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          git fetch origin main
+          git checkout main
+          jq --arg v "$VERSION" '.minimum_version = $v' cli-update-policy.json > tmp.json && mv tmp.json cli-update-policy.json
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add cli-update-policy.json
+          git commit -m "chore: update CLI policy minimum_version to ${VERSION}"
+          git push origin main
+


### PR DESCRIPTION
## Summary
- Adds asset verification step after release creation — HEAD-checks all 4 platform tarballs before updating the policy
- Adds auto-commit step that updates `cli-update-policy.json` `minimum_version` on `main` using `jq`
- Both steps skip for prereleases (`-rc`, `-beta`, `-alpha`)

Eliminates the manual step of updating the policy after each release, and ensures it only references a version with downloadable assets.

## Test plan
- [ ] Tag a test release → verify policy file gets auto-committed with new version
- [ ] Verify policy tier and message are preserved, only `minimum_version` changes
- [ ] Tag a prerelease (`-rc`) → verify both steps are skipped