### PR TITLE
Use POLICY_PUSH_TOKEN for release policy bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,8 +192,11 @@ jobs:
 
       - name: Update CLI policy minimum_version
         if: ${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-alpha') }}
+        env:
+          GH_TOKEN: ${{ secrets.POLICY_PUSH_TOKEN }}
         run: |
           VERSION=${GITHUB_REF_NAME#v}
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
           git fetch origin main
           git checkout main
           jq --arg v "$VERSION" '.minimum_version = $v' cli-update-policy.json > tmp.json && mv tmp.json cli-update-policy.json


### PR DESCRIPTION
## Summary
- Uses `POLICY_PUSH_TOKEN` instead of default `GITHUB_TOKEN` to bypass branch protection when pushing the policy update to main

Follow-up to #31 — the default token can't push to protected `main`.

## Test plan
- [ ] Next release tag → verify the policy commit lands on main without permission errors