### PR TITLE
Fix macOS launchd PATH for host docker subprocesses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ export
 .PHONY: lint fix test coverage coverage-text check fmt zip-projects unpack-projects watch \
        docs-version docs-status translate translate-all doc-search doc-search-all
 
-# Check formatting and run clippy. Deny-level lints (configured in Cargo.toml)
-# cause hard failures; warn-level lints are printed but don't block.
+# Check formatting and run clippy. Matches CI: -D warnings promotes all
+# warnings to errors so local lint catches what CI catches.
 lint:
 	cargo fmt --all -- --check
-	cargo clippy --workspace
+	cargo clippy --workspace -- -D warnings
 
 # Auto-format and auto-fix what clippy can.
 fix:

--- a/coast-cli/src/commands/daemon.rs
+++ b/coast-cli/src/commands/daemon.rs
@@ -118,6 +118,7 @@ fn launchd_path_value() -> Option<String> {
     None
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn extend_path_entries<I>(mut existing_entries: Vec<PathBuf>, candidates: I) -> Vec<PathBuf>
 where
     I: IntoIterator<Item = PathBuf>,

--- a/coast-daemon/src/lib.rs
+++ b/coast-daemon/src/lib.rs
@@ -8,7 +8,7 @@ rust_i18n::i18n!("../coast-i18n/locales", fallback = "en");
 use std::sync::Arc;
 
 use clap::Parser;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 
 use coast_core::error::Result;
@@ -94,7 +94,7 @@ fn ensure_host_tool_paths() {
             unsafe {
                 std::env::set_var("PATH", &path);
             }
-            debug!(path = %path.to_string_lossy(), "updated PATH with macOS host tool directories");
+            tracing::debug!(path = %path.to_string_lossy(), "updated PATH with macOS host tool directories");
         }
         Err(error) => {
             warn!(error = %error, "failed to join augmented PATH entries");
@@ -105,6 +105,7 @@ fn ensure_host_tool_paths() {
 #[cfg(not(target_os = "macos"))]
 fn ensure_host_tool_paths() {}
 
+#[cfg(any(target_os = "macos", test))]
 fn extend_path_entries<I>(
     mut existing_entries: Vec<std::path::PathBuf>,
     candidates: I,


### PR DESCRIPTION
## Context

`coastd` shells out to `docker` for host-side image builds. On macOS,
launchd starts the daemon with a stripped `PATH`, so those subprocesses fail
when `docker` lives in standard user-installed locations like
`/opt/homebrew/bin` or `/usr/local/bin`.

On my machine this reproduced as `coast build` failing with:

```text
failed to run docker build for coast image: No such file or directory (os error 2)
```

## Summary

- augment the daemon `PATH` with `/opt/homebrew/bin` and `/usr/local/bin`
  before host-side subprocesses run
- write the augmented `PATH` into generated macOS launchd plists
- add regression tests for PATH extension and plist generation

## Why this shape

- fixes both auto-started launchd daemons and manually started daemons running
  under stripped `PATH` environments
- keeps the change limited to standard user-installed binary directories
- avoids hardcoding OrbStack app bundle internals

## Test Plan

- `cargo fmt --all`
- `COAST_SKIP_UI_BUILD=1 cargo test -p coast-daemon test_extend_path_entries_appends_only_missing_candidates --lib`
- `COAST_SKIP_UI_BUILD=1 cargo test -p coast-cli test_generate_launchd_plist_content`
- `COAST_SKIP_UI_BUILD=1 cargo test -p coast-cli test_extend_path_entries_appends_only_missing_candidates`
- `COAST_SKIP_UI_BUILD=1 cargo build -p coast-daemon --bin coastd-dev -p coast-cli --bin coast-dev`
- `PATH="/usr/bin:/bin:/usr/sbin:/sbin" /Users/af/symphony/coasts/target/debug/coast-dev build` from `/Users/af/symphony`
- `PATH="/usr/bin:/bin:/usr/sbin:/sbin" /Users/af/symphony/coasts/target/debug/coast-dev run pr-check-1` from `/Users/af/symphony`
- `COAST_SKIP_UI_BUILD=1 cargo clippy -p coast-daemon -p coast-cli --all-targets -- -D warnings` fails on pre-existing warnings in untouched files
