### PR TITLE
[dh] fix: compose project name derived from artifact hash when compose is at project root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-tungstenite",
+ "toml",
  "tower",
  "tower-http",
  "tracing",

--- a/coast-daemon/Cargo.toml
+++ b/coast-daemon/Cargo.toml
@@ -52,6 +52,7 @@ rust-embed = { workspace = true }
 mime_guess = "2"
 ts-rs = { workspace = true }
 reqwest = { workspace = true }
+toml = { workspace = true }
 
 [lints]
 workspace = true

--- a/coast-daemon/src/handlers/mod.rs
+++ b/coast-daemon/src/handlers/mod.rs
@@ -83,15 +83,22 @@ pub fn compose_context_for_build(project: &str, build_id: Option<&str>) -> Compo
         None => project_dir.join("latest").join("coastfile.toml"),
     };
 
+    // Read the raw compose path from the TOML text instead of the parsed
+    // Coastfile. Coastfile::from_file resolves relative paths against the
+    // coastfile's parent directory, which inside the artifact dir turns
+    // "./docker-compose.yml" into "<artifact_hash>/docker-compose.yml".
+    // Extracting the parent dir name from that resolved path produces the
+    // artifact hash as the compose project name, breaking `docker compose ps`.
     let compose_rel_dir = if coastfile_path.exists() {
-        coast_core::coastfile::Coastfile::from_file(&coastfile_path)
+        std::fs::read_to_string(&coastfile_path)
             .ok()
-            .and_then(|cf| {
-                cf.compose.as_ref().and_then(|p| {
-                    let parent = p.parent()?;
-                    let dir_name = parent.file_name()?.to_str()?;
-                    Some(dir_name.to_string())
-                })
+            .and_then(|text| {
+                let raw: toml::Value = text.parse().ok()?;
+                let compose_str = raw.get("coast")?.get("compose")?.as_str()?;
+                let compose_path = std::path::Path::new(compose_str);
+                let parent = compose_path.parent()?;
+                let dir_name = parent.file_name()?.to_str()?;
+                Some(dir_name.to_string())
             })
     } else {
         None
@@ -136,6 +143,69 @@ mod compose_context_tests {
         assert!(cmd[2].contains("-p coast-myapp"));
         assert!(cmd[2].contains("/workspace/docker-compose.yml"));
         assert!(cmd[2].contains("logs --tail 200"));
+    }
+
+    #[test]
+    fn test_compose_context_root_level_compose_uses_default_project_name() {
+        // Simulate a coastfile with compose = "./docker-compose.yml" at the project root.
+        // The raw path's parent is "." which has no meaningful dir name,
+        // so compose_rel_dir should be None and project_name should fall
+        // back to "coast-{project}".
+        let dir = tempfile::tempdir().unwrap();
+        let coastfile = dir.path().join("coastfile.toml");
+        std::fs::write(
+            &coastfile,
+            r#"
+[coast]
+name = "my-app"
+compose = "./docker-compose.yml"
+"#,
+        )
+        .unwrap();
+
+        let text = std::fs::read_to_string(&coastfile).unwrap();
+        let raw: toml::Value = text.parse().unwrap();
+        let compose_str = raw
+            .get("coast")
+            .and_then(|c| c.get("compose"))
+            .and_then(|v| v.as_str())
+            .unwrap();
+        let compose_path = std::path::Path::new(compose_str);
+        let parent = compose_path.parent().unwrap();
+        // "." has no file_name component, so this should be None
+        let dir_name = parent.file_name().and_then(|f| f.to_str());
+        assert!(
+            dir_name.is_none(),
+            "root-level compose should not produce a dir name, got: {:?}",
+            dir_name
+        );
+    }
+
+    #[test]
+    fn test_compose_context_subdir_compose_extracts_dir_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let coastfile = dir.path().join("coastfile.toml");
+        std::fs::write(
+            &coastfile,
+            r#"
+[coast]
+name = "my-app"
+compose = "./infra/docker-compose.yml"
+"#,
+        )
+        .unwrap();
+
+        let text = std::fs::read_to_string(&coastfile).unwrap();
+        let raw: toml::Value = text.parse().unwrap();
+        let compose_str = raw
+            .get("coast")
+            .and_then(|c| c.get("compose"))
+            .and_then(|v| v.as_str())
+            .unwrap();
+        let compose_path = std::path::Path::new(compose_str);
+        let parent = compose_path.parent().unwrap();
+        let dir_name = parent.file_name().and_then(|f| f.to_str());
+        assert_eq!(dir_name, Some("infra"));
     }
 }
 


### PR DESCRIPTION
## Summary

- `coast ps` and Coastguard showed all compose services as "down" when `compose = "./docker-compose.yml"` (at the project root)
- Root cause: `compose_context_for_build` used the resolved absolute compose path from `Coastfile::from_file`, which resolves `./docker-compose.yml` relative to the artifact directory, producing a path like `~/.coast/images/.../dae4b418cc38e853_20260305182136/docker-compose.yml`. The parent dir name (`dae4b418cc38e853_20260305182136`) was then used as the `-p` project name for `docker compose ps`, which returned empty results
- Fix: read the raw TOML compose string instead of the resolved `PathBuf`, so root-level compose files correctly produce `compose_rel_dir=None` and `project_name="coast-{project}"`
- Only affects projects with compose at the root. Projects with compose in a subdirectory (e.g. `./infra/docker-compose.yml`) were unaffected

## Test plan

- [x] All 2,048 existing tests pass
- [x] Added 2 new tests covering root-level and subdirectory compose path extraction
- [x] Verified end-to-end: `coast ps` shows all services as "running" after fix