### PR TITLE
Respect active Docker contexts when resolving the host engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "chrono",
  "clap",
  "coast-core",
+ "coast-docker",
  "coast-i18n",
  "coast-update",
  "colored",

--- a/coast-cli/Cargo.toml
+++ b/coast-cli/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/bin/coast-dev.rs"
 
 [dependencies]
 coast-core = { path = "../coast-core" }
+coast-docker = { path = "../coast-docker" }
 coast-i18n = { path = "../coast-i18n" }
 coast-update = { path = "../coast-update" }
 rust-i18n = { workspace = true }

--- a/coast-cli/src/commands/doctor.rs
+++ b/coast-cli/src/commands/doctor.rs
@@ -99,8 +99,8 @@ pub async fn execute(args: &DoctorArgs) -> Result<()> {
 
     let db = rusqlite::Connection::open(&db_path).context("Failed to open state database")?;
 
-    let docker = bollard::Docker::connect_with_local_defaults()
-        .context("Failed to connect to Docker. Is Docker running?")?;
+    let docker = coast_docker::host::connect_to_host_docker()
+        .context("Failed to connect to Docker. Is Docker running and is your active Docker context reachable?")?;
 
     let mut fixes: Vec<String> = Vec::new();
     let mut findings: Vec<String> = Vec::new();

--- a/coast-cli/src/commands/nuke.rs
+++ b/coast-cli/src/commands/nuke.rs
@@ -63,7 +63,7 @@ pub async fn execute(args: &NukeArgs) -> Result<()> {
         ..Default::default()
     };
 
-    match bollard::Docker::connect_with_local_defaults() {
+    match coast_docker::host::connect_to_host_docker() {
         Ok(docker) => {
             report.containers_removed = remove_containers(&docker).await;
             report.volumes_removed = remove_volumes(&docker).await;

--- a/coast-daemon/src/server.rs
+++ b/coast-daemon/src/server.rs
@@ -186,7 +186,13 @@ pub struct AppState {
 impl AppState {
     /// Create a new `AppState` with the given state database and Docker client.
     pub fn new(db: StateDb) -> Self {
-        let docker = bollard::Docker::connect_with_local_defaults().ok();
+        let docker = match coast_docker::host::connect_to_host_docker() {
+            Ok(docker) => Some(docker),
+            Err(error) => {
+                warn!(error = %error, "Docker is unavailable at daemon startup");
+                None
+            }
+        };
         let (event_bus, _) = tokio::sync::broadcast::channel(256);
         let initial_lang = db.get_language().unwrap_or_else(|_| "en".to_string());
         let (language_tx, language_rx) = tokio::sync::watch::channel(initial_lang);

--- a/coast-docker/src/dind.rs
+++ b/coast-docker/src/dind.rs
@@ -16,6 +16,7 @@ use tracing::{debug, info};
 
 use coast_core::error::{CoastError, Result};
 
+use crate::host::connect_to_host_docker;
 use crate::runtime::{BindMount, ContainerConfig, ExecResult, Runtime, VolumeMount};
 
 /// The default Docker image used for DinD coast containers.
@@ -34,10 +35,7 @@ pub struct DindRuntime {
 impl DindRuntime {
     /// Create a new DinD runtime connected to the default Docker socket.
     pub fn new() -> Result<Self> {
-        let docker = Docker::connect_with_local_defaults().map_err(|e| CoastError::Docker {
-            message: format!("Failed to connect to Docker daemon. Is Docker running? Error: {e}"),
-            source: Some(Box::new(e)),
-        })?;
+        let docker = connect_to_host_docker()?;
         Ok(Self { docker })
     }
 

--- a/coast-docker/src/host.rs
+++ b/coast-docker/src/host.rs
@@ -1,0 +1,392 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use bollard::{Docker, API_DEFAULT_VERSION};
+use serde::Deserialize;
+
+use coast_core::error::{CoastError, Result};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 120;
+
+#[cfg(unix)]
+const DEFAULT_LOCAL_DOCKER_HOST: &str = "unix:///var/run/docker.sock";
+
+#[cfg(windows)]
+const DEFAULT_LOCAL_DOCKER_HOST: &str = "npipe:////./pipe/docker_engine";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DockerEndpointSource {
+    EnvHost,
+    EnvContext,
+    ConfigContext,
+    DefaultLocal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DockerEndpoint {
+    pub host: String,
+    pub source: DockerEndpointSource,
+    pub context: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DockerCliConfig {
+    #[serde(rename = "currentContext")]
+    current_context: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContextMeta {
+    #[serde(rename = "Name")]
+    name: String,
+    #[serde(rename = "Endpoints")]
+    endpoints: std::collections::HashMap<String, ContextEndpoint>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContextEndpoint {
+    #[serde(rename = "Host")]
+    host: Option<String>,
+}
+
+pub fn connect_to_host_docker() -> Result<Docker> {
+    let docker_config_dir = env::var_os("DOCKER_CONFIG").map(PathBuf::from);
+    let env_host = env::var("DOCKER_HOST").ok();
+    let env_context = env::var("DOCKER_CONTEXT").ok();
+
+    connect_to_host_docker_with(
+        docker_config_dir.as_deref(),
+        env_host.as_deref(),
+        env_context.as_deref(),
+    )
+}
+
+fn connect_to_host_docker_with(
+    docker_config_dir: Option<&Path>,
+    env_host: Option<&str>,
+    env_context: Option<&str>,
+) -> Result<Docker> {
+    let endpoint = resolve_docker_endpoint(docker_config_dir, env_host, env_context)?;
+
+    match endpoint.source {
+        DockerEndpointSource::EnvHost => Docker::connect_with_defaults().map_err(|e| {
+            CoastError::docker(format!(
+                "Failed to connect to Docker using DOCKER_HOST='{}'. Error: {e}",
+                endpoint.host
+            ))
+        }),
+        _ => connect_to_endpoint(&endpoint),
+    }
+}
+
+pub fn resolve_docker_endpoint(
+    docker_config_dir: Option<&Path>,
+    env_host: Option<&str>,
+    env_context: Option<&str>,
+) -> Result<DockerEndpoint> {
+    let config_dir = docker_config_dir
+        .map(Path::to_path_buf)
+        .or_else(default_docker_config_dir);
+
+    if let Some(raw_context) = normalize_env_value(env_context) {
+        if raw_context == "default" {
+            return Ok(DockerEndpoint {
+                host: DEFAULT_LOCAL_DOCKER_HOST.to_string(),
+                source: DockerEndpointSource::DefaultLocal,
+                context: None,
+            });
+        }
+
+        let host = resolve_context_host(config_dir.as_deref(), raw_context)?;
+        return Ok(DockerEndpoint {
+            host,
+            source: DockerEndpointSource::EnvContext,
+            context: Some(raw_context.to_string()),
+        });
+    }
+
+    if let Some(host) = normalize_env_value(env_host) {
+        return Ok(DockerEndpoint {
+            host: host.to_string(),
+            source: DockerEndpointSource::EnvHost,
+            context: None,
+        });
+    }
+
+    if let Some(config_dir) = config_dir.as_deref() {
+        if let Some(context) = current_context_from_config(config_dir)? {
+            let host = resolve_context_host(Some(config_dir), &context)?;
+            return Ok(DockerEndpoint {
+                host,
+                source: DockerEndpointSource::ConfigContext,
+                context: Some(context),
+            });
+        }
+    }
+
+    Ok(DockerEndpoint {
+        host: DEFAULT_LOCAL_DOCKER_HOST.to_string(),
+        source: DockerEndpointSource::DefaultLocal,
+        context: None,
+    })
+}
+
+fn connect_to_endpoint(endpoint: &DockerEndpoint) -> Result<Docker> {
+    let host = endpoint.host.as_str();
+    let context_msg = endpoint
+        .context
+        .as_ref()
+        .map(|name| format!("Docker context '{name}'"))
+        .unwrap_or_else(|| "resolved Docker host".to_string());
+
+    #[cfg(any(unix, windows))]
+    if host.starts_with("unix://") || host.starts_with("npipe://") {
+        return Docker::connect_with_socket(host, DEFAULT_TIMEOUT_SECS, API_DEFAULT_VERSION)
+            .map_err(|e| {
+                CoastError::docker(format!(
+                    "Failed to connect to {context_msg} at '{}'. Error: {e}",
+                    endpoint.host
+                ))
+            });
+    }
+
+    if host.starts_with("tcp://") || host.starts_with("http://") {
+        return Docker::connect_with_http(host, DEFAULT_TIMEOUT_SECS, API_DEFAULT_VERSION).map_err(
+            |e| {
+                CoastError::docker(format!(
+                    "Failed to connect to {context_msg} at '{}'. Error: {e}",
+                    endpoint.host
+                ))
+            },
+        );
+    }
+
+    Err(CoastError::docker(format!(
+        "Unsupported Docker endpoint '{}' from {context_msg}. \
+         Set DOCKER_HOST explicitly if this engine requires a transport Coasts does not yet auto-resolve.",
+        endpoint.host
+    )))
+}
+
+fn normalize_env_value(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn normalize_context_name(value: Option<&str>) -> Option<String> {
+    match normalize_env_value(value) {
+        Some("default") | None => None,
+        Some(value) => Some(value.to_string()),
+    }
+}
+
+fn default_docker_config_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".docker"))
+}
+
+fn current_context_from_config(config_dir: &Path) -> Result<Option<String>> {
+    let config_path = config_dir.join("config.json");
+    if !config_path.exists() {
+        return Ok(None);
+    }
+
+    let contents = fs::read_to_string(&config_path).map_err(|e| CoastError::Docker {
+        message: format!(
+            "Failed to read Docker config '{}'. Error: {e}",
+            config_path.display()
+        ),
+        source: Some(Box::new(e)),
+    })?;
+
+    let config: DockerCliConfig =
+        serde_json::from_str(&contents).map_err(|e| CoastError::Docker {
+            message: format!(
+                "Failed to parse Docker config '{}'. Error: {e}",
+                config_path.display()
+            ),
+            source: Some(Box::new(e)),
+        })?;
+
+    Ok(normalize_context_name(config.current_context.as_deref()))
+}
+
+fn resolve_context_host(config_dir: Option<&Path>, context_name: &str) -> Result<String> {
+    let Some(config_dir) = config_dir else {
+        return Err(CoastError::docker(format!(
+            "Docker context '{context_name}' was requested, but no Docker config directory could be found."
+        )));
+    };
+
+    let meta_root = config_dir.join("contexts").join("meta");
+    if !meta_root.exists() {
+        return Err(CoastError::docker(format!(
+            "Docker context '{context_name}' was requested, but '{}' does not exist.",
+            meta_root.display()
+        )));
+    }
+
+    for entry in fs::read_dir(&meta_root).map_err(|e| CoastError::Docker {
+        message: format!(
+            "Failed to read Docker contexts in '{}'. Error: {e}",
+            meta_root.display()
+        ),
+        source: Some(Box::new(e)),
+    })? {
+        let entry = entry.map_err(|e| CoastError::Docker {
+            message: format!(
+                "Failed to inspect Docker context metadata in '{}'. Error: {e}",
+                meta_root.display()
+            ),
+            source: Some(Box::new(e)),
+        })?;
+
+        let meta_path = entry.path().join("meta.json");
+        if !meta_path.exists() {
+            continue;
+        }
+
+        let contents = fs::read_to_string(&meta_path).map_err(|e| CoastError::Docker {
+            message: format!(
+                "Failed to read Docker context metadata '{}'. Error: {e}",
+                meta_path.display()
+            ),
+            source: Some(Box::new(e)),
+        })?;
+        let meta: ContextMeta =
+            serde_json::from_str(&contents).map_err(|e| CoastError::Docker {
+                message: format!(
+                    "Failed to parse Docker context metadata '{}'. Error: {e}",
+                    meta_path.display()
+                ),
+                source: Some(Box::new(e)),
+            })?;
+
+        if meta.name != context_name {
+            continue;
+        }
+
+        let host = meta
+            .endpoints
+            .get("docker")
+            .and_then(|endpoint| endpoint.host.as_deref())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                CoastError::docker(format!(
+                    "Docker context '{context_name}' has no docker endpoint host in '{}'.",
+                    meta_path.display()
+                ))
+            })?;
+
+        return Ok(host.to_string());
+    }
+
+    Err(CoastError::docker(format!(
+        "Docker context '{context_name}' was not found under '{}'.",
+        meta_root.display()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use tempfile::TempDir;
+
+    fn write_json(path: &Path, contents: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn resolves_env_host_before_config_context() {
+        let temp = TempDir::new().unwrap();
+        write_json(
+            &temp.path().join("config.json"),
+            r#"{"currentContext":"orbstack"}"#,
+        );
+
+        let endpoint =
+            resolve_docker_endpoint(Some(temp.path()), Some("unix:///tmp/docker.sock"), None)
+                .unwrap();
+
+        assert_eq!(endpoint.source, DockerEndpointSource::EnvHost);
+        assert_eq!(endpoint.host, "unix:///tmp/docker.sock");
+    }
+
+    #[test]
+    fn resolves_explicit_context_from_meta_store() {
+        let temp = TempDir::new().unwrap();
+        write_json(
+            &temp.path().join("contexts/meta/hash/meta.json"),
+            r#"{"Name":"orbstack","Endpoints":{"docker":{"Host":"unix:///Users/test/.orbstack/run/docker.sock"}}}"#,
+        );
+
+        let endpoint = resolve_docker_endpoint(Some(temp.path()), None, Some("orbstack")).unwrap();
+
+        assert_eq!(endpoint.source, DockerEndpointSource::EnvContext);
+        assert_eq!(
+            endpoint.host,
+            "unix:///Users/test/.orbstack/run/docker.sock"
+        );
+        assert_eq!(endpoint.context.as_deref(), Some("orbstack"));
+    }
+
+    #[test]
+    fn explicit_context_overrides_docker_host() {
+        let temp = TempDir::new().unwrap();
+        write_json(
+            &temp.path().join("contexts/meta/hash/meta.json"),
+            r#"{"Name":"orbstack","Endpoints":{"docker":{"Host":"unix:///Users/test/.orbstack/run/docker.sock"}}}"#,
+        );
+
+        let endpoint = resolve_docker_endpoint(
+            Some(temp.path()),
+            Some("unix:///tmp/docker.sock"),
+            Some("orbstack"),
+        )
+        .unwrap();
+
+        assert_eq!(endpoint.source, DockerEndpointSource::EnvContext);
+        assert_eq!(
+            endpoint.host,
+            "unix:///Users/test/.orbstack/run/docker.sock"
+        );
+    }
+
+    #[test]
+    fn resolves_current_context_from_config_when_env_is_unset() {
+        let temp = TempDir::new().unwrap();
+        write_json(
+            &temp.path().join("config.json"),
+            r#"{"currentContext":"orbstack"}"#,
+        );
+        write_json(
+            &temp.path().join("contexts/meta/hash/meta.json"),
+            r#"{"Name":"orbstack","Endpoints":{"docker":{"Host":"unix:///Users/test/.orbstack/run/docker.sock"}}}"#,
+        );
+
+        let endpoint = resolve_docker_endpoint(Some(temp.path()), None, None).unwrap();
+
+        assert_eq!(endpoint.source, DockerEndpointSource::ConfigContext);
+        assert_eq!(endpoint.context.as_deref(), Some("orbstack"));
+    }
+
+    #[test]
+    fn explicit_default_context_falls_back_to_default_socket() {
+        let endpoint =
+            resolve_docker_endpoint(None, Some("unix:///tmp/docker.sock"), Some("default"))
+                .unwrap();
+
+        assert_eq!(endpoint.source, DockerEndpointSource::DefaultLocal);
+        assert_eq!(endpoint.host, DEFAULT_LOCAL_DOCKER_HOST);
+    }
+
+    #[test]
+    fn missing_context_is_actionable() {
+        let temp = TempDir::new().unwrap();
+        let error = resolve_docker_endpoint(Some(temp.path()), None, Some("missing")).unwrap_err();
+
+        assert!(error.to_string().contains("Docker context 'missing'"));
+    }
+}

--- a/coast-docker/src/lib.rs
+++ b/coast-docker/src/lib.rs
@@ -7,6 +7,7 @@ pub mod compose;
 pub mod compose_build;
 pub mod container;
 pub mod dind;
+pub mod host;
 pub mod image_cache;
 pub mod network;
 pub mod podman;

--- a/coast-docker/src/network.rs
+++ b/coast-docker/src/network.rs
@@ -11,6 +11,8 @@ use tracing::{debug, info, warn};
 
 use coast_core::error::{CoastError, Result};
 
+use crate::host::connect_to_host_docker;
+
 /// Prefix for coast shared network names.
 pub const NETWORK_PREFIX: &str = "coast-shared-";
 
@@ -36,10 +38,7 @@ pub struct NetworkManager {
 impl NetworkManager {
     /// Create a new network manager connected to the default Docker socket.
     pub fn new() -> Result<Self> {
-        let docker = Docker::connect_with_local_defaults().map_err(|e| CoastError::Docker {
-            message: format!("Failed to connect to Docker daemon: {e}"),
-            source: Some(Box::new(e)),
-        })?;
+        let docker = connect_to_host_docker()?;
         Ok(Self { docker })
     }
 

--- a/coast-docker/src/podman.rs
+++ b/coast-docker/src/podman.rs
@@ -14,6 +14,7 @@ use tracing::{debug, info};
 
 use coast_core::error::{CoastError, Result};
 
+use crate::host::connect_to_host_docker;
 use crate::runtime::{ContainerConfig, ExecResult, Runtime};
 
 /// The default image used for Podman coast containers.
@@ -41,14 +42,7 @@ pub struct PodmanRuntime {
 impl PodmanRuntime {
     /// Create a new Podman runtime connected to the default Docker socket.
     pub fn new() -> Result<Self> {
-        let docker = Docker::connect_with_local_defaults().map_err(|e| CoastError::Docker {
-            message: format!(
-                "Failed to connect to Docker daemon. Is Docker running? \
-                 The Podman runtime still requires Docker on the host to \
-                 manage coast containers. Error: {e}"
-            ),
-            source: Some(Box::new(e)),
-        })?;
+        let docker = connect_to_host_docker()?;
         Ok(Self { docker })
     }
 

--- a/coast-docker/src/sysbox.rs
+++ b/coast-docker/src/sysbox.rs
@@ -14,6 +14,7 @@ use tracing::{debug, info};
 
 use coast_core::error::{CoastError, Result};
 
+use crate::host::connect_to_host_docker;
 use crate::runtime::{ContainerConfig, ExecResult, Runtime};
 
 /// The default Docker image used for Sysbox coast containers.
@@ -41,10 +42,7 @@ pub struct SysboxRuntime {
 impl SysboxRuntime {
     /// Create a new Sysbox runtime connected to the default Docker socket.
     pub fn new() -> Result<Self> {
-        let docker = Docker::connect_with_local_defaults().map_err(|e| CoastError::Docker {
-            message: format!("Failed to connect to Docker daemon. Is Docker running? Error: {e}"),
-            source: Some(Box::new(e)),
-        })?;
+        let docker = connect_to_host_docker()?;
         Ok(Self { docker })
     }
 


### PR DESCRIPTION
## Summary

This is PR 1 of 2 for #60.

It teaches Coasts to resolve the host Docker endpoint using Docker's documented precedence instead of assuming the default local socket:

- explicit `DOCKER_CONTEXT`
- explicit `DOCKER_HOST`
- `currentContext` from `~/.docker/config.json`
- default local socket fallback

That keeps explicit `DOCKER_HOST` behavior intact while making local Docker-context setups like OrbStack work without manual `DOCKER_HOST` exports.

## What changed

- added a shared host Docker resolver in `coast-docker`
- wired daemon startup to use that resolver for `state.docker`
- wired runtime constructors (`dind`, `sysbox`, `podman`, shared-network manager) to the same resolver
- wired `coast doctor` and `coast nuke` to the same path
- added resolver tests for env host, explicit context, config currentContext, and missing-context handling

## Why this is separate from PR 2

This PR only fixes endpoint resolution.
It does not change `coast run` state-machine behavior yet.

The follow-up PR will make `coast run` fail before touching state when Docker is unavailable, so the daemon can never persist a running instance with no container ID or port allocations.

## Validation

- `cargo test -p coast-docker --lib`
- `cargo test -p coast-cli doctor:: -- --nocapture`

## Repro context

This was reproduced on a machine where:

- `docker context show` => `orbstack`
- `docker context inspect --format '{{.Endpoints.docker.Host}}'` => `unix:///Users/<user>/.orbstack/run/docker.sock`
- `docker info` succeeded
- Coasts still treated Docker as unavailable because it only tried the default local socket

## Notes

I opened issue #60 first to avoid a drive-by PR and split the fix into small reviewable slices.
I have not attached a Loom yet from this environment; happy to add an equivalent walkthrough if you want one before review.
