### PR TITLE
Fail coast run before it can persist invalid state

### DIFF
--- a/coast-daemon/src/handlers/run/mod.rs
+++ b/coast-daemon/src/handlers/run/mod.rs
@@ -185,6 +185,14 @@ pub async fn handle(
 ) -> Result<RunResponse> {
     info!(name = %req.name, project = %req.project, branch = ?req.branch, "handling run request");
 
+    if state.docker.is_none() {
+        return Err(coast_core::error::CoastError::docker(
+            "Host Docker is not available. `coast run` requires a Docker-compatible host engine. \
+             If you use Docker contexts (OrbStack, Colima, Rancher Desktop, Docker Desktop), \
+             ensure coastd can resolve the active context and then restart the daemon.",
+        ));
+    }
+
     // Phase 1: Validate, resolve build_id, insert instance record
     let validated = validate::validate_and_insert(&req, state, &progress).await?;
 
@@ -287,7 +295,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_run_creates_instance() {
+    async fn test_run_without_docker_fails_before_inserting_instance() {
         let state = test_state();
         let req = RunRequest {
             name: "feature-oauth".to_string(),
@@ -301,81 +309,13 @@ mod tests {
         };
         let (tx, _rx) = tokio::sync::mpsc::channel(64);
         let result = handle(req, &state, tx).await;
-        assert!(result.is_ok());
-        let resp = result.unwrap();
-        assert_eq!(resp.name, "feature-oauth");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Host Docker is not available"));
 
-        // Verify in DB
         let db = state.db.lock().await;
         let instance = db.get_instance("my-app", "feature-oauth").unwrap();
-        assert!(instance.is_some());
-        let instance = instance.unwrap();
-        assert_eq!(instance.status, coast_core::types::InstanceStatus::Running);
-        assert_eq!(instance.branch, Some("feature/oauth".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_run_duplicate_instance_fails() {
-        let state = test_state();
-        let req = RunRequest {
-            name: "dup".to_string(),
-            project: "my-app".to_string(),
-            branch: None,
-            commit_sha: None,
-            worktree: None,
-            build_id: None,
-            coastfile_type: None,
-            force_remove_dangling: false,
-        };
-        let (tx, _rx) = tokio::sync::mpsc::channel(64);
-        let result = handle(req.clone(), &state, tx).await;
-        assert!(result.is_ok());
-
-        // Second run should fail
-        let req2 = RunRequest {
-            name: "dup".to_string(),
-            project: "my-app".to_string(),
-            branch: None,
-            commit_sha: None,
-            worktree: None,
-            build_id: None,
-            coastfile_type: None,
-            force_remove_dangling: false,
-        };
-        let (tx2, _rx2) = tokio::sync::mpsc::channel(64);
-        let result2 = handle(req2, &state, tx2).await;
-        assert!(result2.is_err());
-        let err = result2.unwrap_err().to_string();
-        assert!(err.contains("already exists"));
-    }
-
-    #[tokio::test]
-    async fn test_run_different_projects_same_name() {
-        let state = test_state();
-        let req1 = RunRequest {
-            name: "main".to_string(),
-            project: "project-a".to_string(),
-            branch: None,
-            commit_sha: None,
-            worktree: None,
-            build_id: None,
-            coastfile_type: None,
-            force_remove_dangling: false,
-        };
-        let req2 = RunRequest {
-            name: "main".to_string(),
-            project: "project-b".to_string(),
-            branch: None,
-            commit_sha: None,
-            worktree: None,
-            build_id: None,
-            coastfile_type: None,
-            force_remove_dangling: false,
-        };
-        let (tx1, _rx1) = tokio::sync::mpsc::channel(64);
-        assert!(handle(req1, &state, tx1).await.is_ok());
-        let (tx2, _rx2) = tokio::sync::mpsc::channel(64);
-        assert!(handle(req2, &state, tx2).await.is_ok());
+        assert!(instance.is_none());
     }
 
     #[test]
@@ -427,7 +367,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_run_with_force_remove_dangling_no_docker_succeeds() {
+    async fn test_run_with_force_remove_dangling_still_fails_without_docker() {
         let state = test_state();
         let req = RunRequest {
             name: "force-test".to_string(),
@@ -441,9 +381,9 @@ mod tests {
         };
         let (tx, _rx) = tokio::sync::mpsc::channel(64);
         let result = handle(req, &state, tx).await;
-        assert!(result.is_ok());
-        let resp = result.unwrap();
-        assert_eq!(resp.name, "force-test");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Host Docker is not available"));
     }
 
     #[test]

--- a/coast-daemon/src/handlers/run/validate.rs
+++ b/coast-daemon/src/handlers/run/validate.rs
@@ -244,6 +244,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_validate_allows_same_name_in_different_projects() {
+        let db = StateDb::open_in_memory().unwrap();
+        let state = AppState::new_for_testing(db);
+        let progress = discard_progress();
+
+        let req_a = coast_core::protocol::RunRequest {
+            name: "main".to_string(),
+            project: "project-a".to_string(),
+            branch: None,
+            worktree: None,
+            build_id: None,
+            commit_sha: None,
+            coastfile_type: None,
+            force_remove_dangling: false,
+        };
+        let req_b = coast_core::protocol::RunRequest {
+            name: "main".to_string(),
+            project: "project-b".to_string(),
+            branch: None,
+            worktree: None,
+            build_id: None,
+            commit_sha: None,
+            coastfile_type: None,
+            force_remove_dangling: false,
+        };
+
+        validate_and_insert(&req_a, &state, &progress)
+            .await
+            .unwrap();
+        validate_and_insert(&req_b, &state, &progress)
+            .await
+            .unwrap();
+
+        let db = state.db.lock().await;
+        assert!(db.get_instance("project-a", "main").unwrap().is_some());
+        assert!(db.get_instance("project-b", "main").unwrap().is_some());
+    }
+
+    #[tokio::test]
     async fn test_validate_replaces_enqueued() {
         let db = StateDb::open_in_memory().unwrap();
         db.insert_instance(&CoastInstance {


### PR DESCRIPTION
## Summary

This is PR 2 of 2 for #60.

It makes `coast run` fail before touching state when no host Docker client is available.

That prevents the daemon from creating instances that appear running but have no container ID or port allocations.

## What changed

- `run::handle` now returns a Docker error immediately when `state.docker` is unavailable
- the old no-Docker `run` tests were replaced with the correct invariant:
  - fail before inserting state
  - `--force-remove-dangling` does not bypass missing Docker
- duplicate-name and cross-project name semantics are explicitly covered at the validation layer

## Why this is separate from PR 1

PR 1 fixes Docker endpoint discovery.
This PR fixes the `run` state machine so that, even if Docker is unavailable for any reason, Coasts does not persist corrupt running-instance state.

## Validation

With `COAST_SKIP_UI_BUILD=1` and a minimal local `coast-guard/dist/index.html` stub to avoid unrelated frontend build failures:

- `cargo test -p coast-daemon test_validate_rejects_duplicate -- --nocapture`
- `cargo test -p coast-daemon test_validate_allows_same_name_in_different_projects -- --nocapture`
- `cargo test -p coast-daemon test_run_without_docker_fails_before_inserting_instance -- --nocapture`
- `cargo test -p coast-daemon test_run_with_force_remove_dangling_still_fails_without_docker -- --nocapture`

## Context

This is the follow-up to the issue reproduction in #60. The bad state was reproducible when Docker was unavailable to the daemon but `coast run` still inserted and finalized an instance record.
