### PR TITLE
[dh] fix: opt release workflow into Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-macos:


### PR DESCRIPTION
Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true to silence Node.js 20 deprecation warnings from upload-artifact, download-artifact, and softprops/action-gh-release before the June 2026 forced migration.