### PR TITLE
[dh] fix: clipboard fallback for non-secure contexts

### DIFF
--- a/coast-guard/src/components/DocsViewer.tsx
+++ b/coast-guard/src/components/DocsViewer.tsx
@@ -74,11 +74,27 @@ function resolveImageSrc(src: string, basePath: string): string {
   return src;
 }
 
+function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard) {
+    return navigator.clipboard.writeText(text);
+  }
+  // Fallback for non-secure contexts (e.g. http://localcoast:31415)
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
+  return Promise.resolve();
+}
+
 function TextFileModal({ filename, content, onClose }: { filename: string; content: string; onClose: () => void }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
-    void navigator.clipboard.writeText(content).then(() => {
+    void copyToClipboard(content).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
@@ -163,7 +179,7 @@ function PromptCopyButton({
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
-    void navigator.clipboard.writeText(text).then(() => {
+    void copyToClipboard(text).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
@@ -196,7 +212,7 @@ function CopyableCodeBlock({
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
-    void navigator.clipboard.writeText(text).then(() => {
+    void copyToClipboard(text).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });


### PR DESCRIPTION
navigator.clipboard is undefined when served over plain HTTP on a non-localhost hostname (e.g. http://localcoast:31415). Fall back to execCommand('copy') via a temporary textarea.