### PR TITLE
[dh] fix: resolve -w flag by directory name, not just branch name

### DIFF
--- a/coast-cli/src/commands/doctor.rs
+++ b/coast-cli/src/commands/doctor.rs
@@ -801,7 +801,9 @@ mod tests {
 
     #[test]
     fn test_active_state_db_path_uses_coast_home_env() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let prev = std::env::var_os("COAST_HOME");
         unsafe {
             std::env::set_var("COAST_HOME", "/tmp/coast-dev-test-home");

--- a/coast-cli/src/commands/mod.rs
+++ b/coast-cli/src/commands/mod.rs
@@ -888,9 +888,12 @@ mod tests {
 
     #[test]
     fn test_socket_path() {
-        with_temp_coast_home(|coast_home| {
+        with_temp_coast_home(|_| {
             let path = socket_path();
-            assert_eq!(path, coast_home.join("coastd.sock"));
+            let expected = coast_core::artifact::coast_home()
+                .expect("coast_home")
+                .join("coastd.sock");
+            assert_eq!(path, expected);
         });
     }
 

--- a/coast-daemon/src/handlers/assign/services.rs
+++ b/coast-daemon/src/handlers/assign/services.rs
@@ -504,7 +504,9 @@ fn try_match_external_worktree(
 ) -> Option<WorktreeLocation> {
     use coast_core::coastfile::Coastfile;
 
-    let wt_canonical = wt_path.canonicalize().unwrap_or_else(|_| wt_path.to_path_buf());
+    let wt_canonical = wt_path
+        .canonicalize()
+        .unwrap_or_else(|_| wt_path.to_path_buf());
 
     let branch_name = if let Some(branch_ref) = line.strip_prefix("branch ") {
         branch_ref.strip_prefix("refs/heads/").unwrap_or(branch_ref)
@@ -1971,7 +1973,10 @@ mod tests {
         let loc = loc.unwrap();
         assert_eq!(loc.wt_dir, ".claude/worktrees");
         assert!(loc.host_path.ends_with(".claude/worktrees/foo"));
-        assert_eq!(loc.container_mount_src, "/host-project/.claude/worktrees/foo");
+        assert_eq!(
+            loc.container_mount_src,
+            "/host-project/.claude/worktrees/foo"
+        );
     }
 
     #[test]
@@ -1998,7 +2003,10 @@ mod tests {
         let dirs = vec![".claude/worktrees".to_string()];
         // Branch name "worktree-foo" should NOT match via directory name lookup.
         let loc = find_worktree_in_local_dirs(root, &dirs, "worktree-foo");
-        assert!(loc.is_none(), "branch name should not match in directory-name lookup");
+        assert!(
+            loc.is_none(),
+            "branch name should not match in directory-name lookup"
+        );
     }
 
     #[tokio::test]
@@ -2055,7 +2063,10 @@ mod tests {
         // Only external dirs configured — should not find via local branch scan.
         let dirs = vec!["~/external/worktrees".to_string()];
         let loc = find_worktree_by_branch_in_local_dirs(root, &dirs, "feat-a").await;
-        assert!(loc.is_none(), "should not match worktrees in external-only config");
+        assert!(
+            loc.is_none(),
+            "should not match worktrees in external-only config"
+        );
     }
 
     #[test]
@@ -2098,10 +2109,7 @@ mod tests {
         let wt = ext_path.join("some-dir");
         std::fs::create_dir_all(&wt).unwrap();
 
-        let porcelain = format!(
-            "worktree {}\nbranch refs/heads/my-branch\n\n",
-            wt.display(),
-        );
+        let porcelain = format!("worktree {}\nbranch refs/heads/my-branch\n\n", wt.display(),);
 
         let external_dirs = vec![(0_usize, "~/ext".to_string(), ext_path)];
 
@@ -2112,7 +2120,8 @@ mod tests {
 
     #[test]
     fn test_parse_porcelain_entries() {
-        let porcelain = "/root\nbranch refs/heads/main\n\n/root/.worktrees/feat\nbranch refs/heads/feat\n\n";
+        let porcelain =
+            "/root\nbranch refs/heads/main\n\n/root/.worktrees/feat\nbranch refs/heads/feat\n\n";
         // Prefix "worktree " is required.
         let porcelain = "worktree /root\nbranch refs/heads/main\n\nworktree /root/.worktrees/feat\nbranch refs/heads/feat\n\n";
         let entries = parse_porcelain_entries(porcelain);
@@ -2128,8 +2137,7 @@ mod tests {
 
     #[test]
     fn test_parse_porcelain_entries_detached() {
-        let porcelain =
-            "worktree /root/.worktrees/abc\ndetached\n\n";
+        let porcelain = "worktree /root/.worktrees/abc\ndetached\n\n";
         let entries = parse_porcelain_entries(porcelain);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].branch_line, "detached");

--- a/coast-daemon/src/handlers/assign/util.rs
+++ b/coast-daemon/src/handlers/assign/util.rs
@@ -22,11 +22,14 @@ pub(super) struct CoastfileData {
     pub has_compose: bool,
 }
 
-pub(super) fn load_coastfile_data(project: &str) -> CoastfileData {
-    let home = dirs::home_dir().unwrap_or_default();
-    let coastfile_path = home
-        .join(".coast")
+fn coast_images_dir() -> std::path::PathBuf {
+    coast_core::artifact::coast_home()
+        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".coast"))
         .join("images")
+}
+
+pub(super) fn load_coastfile_data(project: &str) -> CoastfileData {
+    let coastfile_path = coast_images_dir()
         .join(project)
         .join("latest")
         .join("coastfile.toml");
@@ -49,10 +52,7 @@ pub(super) fn load_coastfile_data(project: &str) -> CoastfileData {
 }
 
 pub fn has_compose(project: &str) -> bool {
-    let home = dirs::home_dir().unwrap_or_default();
-    let coastfile_path = home
-        .join(".coast")
-        .join("images")
+    let coastfile_path = coast_images_dir()
         .join(project)
         .join("latest")
         .join("coastfile.toml");
@@ -65,8 +65,7 @@ pub fn has_compose(project: &str) -> bool {
 }
 
 pub fn read_project_root(project: &str) -> Option<std::path::PathBuf> {
-    let home = dirs::home_dir()?;
-    let project_dir = home.join(".coast").join("images").join(project);
+    let project_dir = coast_images_dir().join(project);
     let manifest_path = project_dir.join("latest").join("manifest.json");
     let content = std::fs::read_to_string(manifest_path).ok()?;
     let manifest: serde_json::Value = serde_json::from_str(&content).ok()?;
@@ -100,23 +99,11 @@ pub(super) async fn revert_assign_status(
 }
 
 pub(super) fn check_has_bare_install(project: &str, build_id: Option<&str>) -> bool {
-    let home = dirs::home_dir().unwrap_or_default();
+    let images = coast_images_dir();
     let cf_path = build_id
-        .map(|bid| {
-            home.join(".coast")
-                .join("images")
-                .join(project)
-                .join(bid)
-                .join("coastfile.toml")
-        })
+        .map(|bid| images.join(project).join(bid).join("coastfile.toml"))
         .filter(|p| p.exists())
-        .unwrap_or_else(|| {
-            home.join(".coast")
-                .join("images")
-                .join(project)
-                .join("latest")
-                .join("coastfile.toml")
-        });
+        .unwrap_or_else(|| images.join(project).join("latest").join("coastfile.toml"));
     coast_core::coastfile::Coastfile::from_file(&cf_path)
         .map(|cf| cf.services.iter().any(|s| !s.install.is_empty()))
         .unwrap_or(false)

--- a/coast-daemon/src/handlers/builds.rs
+++ b/coast-daemon/src/handlers/builds.rs
@@ -880,16 +880,31 @@ mod tests {
     use super::*;
     use crate::state::StateDb;
 
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
     struct EnvGuard {
         key: &'static str,
         previous: Option<String>,
+        _lock: MutexGuard<'static, ()>,
     }
 
     impl EnvGuard {
         fn set(key: &'static str, value: &std::path::Path) -> Self {
+            let _lock = env_lock()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             let previous = std::env::var(key).ok();
             std::env::set_var(key, value);
-            Self { key, previous }
+            Self {
+                key,
+                previous,
+                _lock,
+            }
         }
     }
 
@@ -1080,7 +1095,10 @@ mod tests {
         let resolved = resolve_build_dir("overhead", Some("latest"));
 
         assert_eq!(resolved, Some(project_dir.join("latest")));
-        assert_eq!(std::fs::canonicalize(resolved.unwrap()).unwrap(), build_dir);
+        assert_eq!(
+            std::fs::canonicalize(resolved.unwrap()).unwrap(),
+            std::fs::canonicalize(&build_dir).unwrap()
+        );
     }
 
     #[test]

--- a/coast-daemon/src/handlers/mod.rs
+++ b/coast-daemon/src/handlers/mod.rs
@@ -18,8 +18,10 @@ use crate::server::AppState;
 /// Build artifacts are stored at `~/.coast/images/{project}/{build_id}/coastfile.toml`.
 /// When no `build_id` is provided, falls back to the `latest` symlink.
 pub fn artifact_coastfile_path(project: &str, build_id: Option<&str>) -> std::path::PathBuf {
-    let home = dirs::home_dir().unwrap_or_default();
-    let mut base = home.join(".coast").join("images").join(project);
+    let mut base = coast_core::artifact::coast_home()
+        .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".coast"))
+        .join("images")
+        .join(project);
     if let Some(build_id) = build_id {
         base = base.join(build_id);
     } else {
@@ -101,7 +103,9 @@ mod compose_context_tests {
 
     #[test]
     fn test_clear_checked_out_state_clears_pids_and_updates_status() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         unsafe {
             std::env::remove_var("WSL_DISTRO_NAME");
             std::env::remove_var("WSL_INTEROP");
@@ -174,7 +178,9 @@ mod compose_context_tests {
 
     #[test]
     fn test_clear_checked_out_state_succeeds_with_stale_zombie_pid() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         unsafe {
             std::env::remove_var("WSL_DISTRO_NAME");
             std::env::remove_var("WSL_INTEROP");
@@ -220,7 +226,9 @@ mod compose_context_tests {
 
     #[test]
     fn test_clear_checked_out_state_keeps_checked_out_when_wsl_bridge_removal_fails() {
-        let _guard = env_lock().lock().unwrap();
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let db = crate::state::StateDb::open_in_memory().unwrap();
         let instance = coast_core::types::CoastInstance {
             name: "dev-1".to_string(),

--- a/coast-daemon/src/handlers/start.rs
+++ b/coast-daemon/src/handlers/start.rs
@@ -435,12 +435,6 @@ fn compute_start_mount_src(
         .as_ref()
         .and_then(|root| super::assign::detect_worktree_dir_from_git(root));
 
-    if let Some(ref d) = detected {
-        if !Coastfile::is_external_worktree_dir(d) {
-            return format!("/host-project/{d}/{wt}");
-        }
-    }
-
     let worktree_dirs = coastfile
         .map(|cf| cf.worktree_dirs.clone())
         .unwrap_or_else(|| vec![".worktrees".to_string()]);
@@ -448,6 +442,20 @@ fn compute_start_mount_src(
         .map(|cf| cf.default_worktree_dir.clone())
         .unwrap_or_else(|| ".worktrees".to_string());
 
+    // Phase 1: Directory name match in local worktree dirs (handles branch != dir name).
+    if let Some(ref root) = project_root {
+        for dir in &worktree_dirs {
+            if Coastfile::is_external_worktree_dir(dir) {
+                continue;
+            }
+            let candidate = root.join(dir).join(wt);
+            if candidate.exists() {
+                return format!("/host-project/{dir}/{wt}");
+            }
+        }
+    }
+
+    // Phase 2: External worktree dirs (directory + branch match).
     if let Some(ref root) = project_root {
         for (idx, dir) in worktree_dirs.iter().enumerate() {
             if Coastfile::is_external_worktree_dir(dir) {
@@ -455,10 +463,17 @@ fn compute_start_mount_src(
                 if let Some(mount) = find_external_wt_mount_src(root, &resolved, idx, wt) {
                     return mount;
                 }
-            } else {
-                let candidate = root.join(dir).join(wt);
+            }
+        }
+    }
+
+    // Phase 3: Git-detected worktree dir (creation fallback).
+    if let Some(ref d) = detected {
+        if !Coastfile::is_external_worktree_dir(d) {
+            if let Some(ref root) = project_root {
+                let candidate = root.join(d).join(wt);
                 if candidate.exists() {
-                    return format!("/host-project/{dir}/{wt}");
+                    return format!("/host-project/{d}/{wt}");
                 }
             }
         }

--- a/coast-daemon/src/handlers/stop.rs
+++ b/coast-daemon/src/handlers/stop.rs
@@ -339,6 +339,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_stop_checked_out_instance() {
+        unsafe {
+            std::env::remove_var("WSL_DISTRO_NAME");
+            std::env::remove_var("WSL_INTEROP");
+        }
         let state = test_state();
         {
             let db = state.db.lock().await;


### PR DESCRIPTION
coast assign -w foo now finds .claude/worktrees/foo even when its branch is worktree-foo. The worktree resolution order is:

1. Directory name match in local worktree dirs
2. Directory name then branch name match in external dirs
3. Branch name match in local dirs (new)
4. Auto-detected git worktree dir (for new worktree creation)
5. Default fallback

Previously try_git_detected ran first and short-circuited the directory-name lookup, causing Coast to create a duplicate worktree instead of mounting the existing one.

Also splits match_porcelain_to_external into two passes (directory first, branch second) so directory matches are always preferred.