### PR TITLE
refactor: extract validation and socat cleanup from stop.rs handle

### DIFF
--- a/coast-daemon/src/handlers/stop.rs
+++ b/coast-daemon/src/handlers/stop.rs
@@ -21,6 +21,54 @@ fn emit(tx: &Option<tokio::sync::mpsc::Sender<BuildProgressEvent>>, event: Build
 
 const TOTAL_STOP_STEPS: u32 = 3;
 
+/// Check whether the given instance status allows stopping.
+///
+/// Returns `Ok(())` for `Running`, `CheckedOut`, and `Idle`. Returns an error
+/// for `Stopped` (already stopped) and transitional states (`Provisioning`,
+/// `Assigning`, `Starting`, `Stopping`, `Unassigning`). `Enqueued` is handled
+/// separately by the caller (removed instead of stopped).
+fn validate_stoppable(status: &InstanceStatus, name: &str) -> Result<()> {
+    match status {
+        InstanceStatus::Running | InstanceStatus::CheckedOut | InstanceStatus::Idle => Ok(()),
+        InstanceStatus::Stopped => Err(CoastError::state(format!(
+            "Instance '{name}' is already stopped. Run `coast start {name}` to start it."
+        ))),
+        InstanceStatus::Provisioning
+        | InstanceStatus::Assigning
+        | InstanceStatus::Starting
+        | InstanceStatus::Stopping
+        | InstanceStatus::Unassigning => Err(CoastError::state(format!(
+            "Instance '{name}' is currently {status}. Wait for the operation to complete."
+        ))),
+        InstanceStatus::Enqueued => Err(CoastError::state(format!(
+            "Instance '{name}' is {status} and cannot be stopped directly."
+        ))),
+    }
+}
+
+/// Kill all socat processes for an instance and clear their PIDs in the DB.
+fn kill_instance_socat_processes(
+    db: &crate::state::StateDb,
+    project: &str,
+    name: &str,
+) -> Result<()> {
+    let port_allocs = db.get_port_allocations(project, name)?;
+    for alloc in &port_allocs {
+        if let Some(pid) = alloc.socat_pid {
+            if let Err(e) = crate::port_manager::kill_socat(pid as u32) {
+                warn!(pid = pid, error = %e, "failed to kill socat process");
+            } else if let Err(e) = db.update_socat_pid(project, name, &alloc.logical_name, None) {
+                warn!(
+                    logical_name = %alloc.logical_name,
+                    error = %e,
+                    "failed to clear socat pid after killing process"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Handle a stop request with optional progress streaming.
 ///
 /// Steps:
@@ -70,22 +118,7 @@ pub async fn handle(
             });
             return Ok(StopResponse { name: req.name });
         }
-        if inst.status == InstanceStatus::Stopped {
-            return Err(CoastError::state(format!(
-                "Instance '{}' is already stopped. Run `coast start {}` to start it.",
-                req.name, req.name
-            )));
-        }
-        if inst.status == InstanceStatus::Provisioning
-            || inst.status == InstanceStatus::Assigning
-            || inst.status == InstanceStatus::Starting
-            || inst.status == InstanceStatus::Stopping
-        {
-            return Err(CoastError::state(format!(
-                "Instance '{}' is currently {}. Wait for the operation to complete.",
-                req.name, inst.status
-            )));
-        }
+        validate_stoppable(&inst.status, &req.name)?;
         if inst.status == InstanceStatus::CheckedOut {
             super::clear_checked_out_state(
                 &db,
@@ -198,22 +231,7 @@ pub async fn handle(
         BuildProgressEvent::started("Killing socat processes", 3, TOTAL_STOP_STEPS),
     );
     let db = state.db.lock().await;
-    let port_allocs = db.get_port_allocations(&req.project, &req.name)?;
-    for alloc in &port_allocs {
-        if let Some(pid) = alloc.socat_pid {
-            if let Err(e) = crate::port_manager::kill_socat(pid as u32) {
-                warn!(pid = pid, error = %e, "failed to kill socat process");
-            } else if let Err(e) =
-                db.update_socat_pid(&req.project, &req.name, &alloc.logical_name, None)
-            {
-                warn!(
-                    logical_name = %alloc.logical_name,
-                    error = %e,
-                    "failed to clear socat pid after killing process"
-                );
-            }
-        }
-    }
+    kill_instance_socat_processes(&db, &req.project, &req.name)?;
     emit(
         &progress,
         BuildProgressEvent::item("Killing socat processes", "socat", "ok"),
@@ -422,5 +440,146 @@ mod tests {
         let db = state.db.lock().await;
         let instance = db.get_instance("my-app", "queued-inst").unwrap();
         assert!(instance.is_none());
+    }
+
+    // --- validate_stoppable tests ---
+
+    #[test]
+    fn test_validate_stoppable_running_ok() {
+        assert!(validate_stoppable(&InstanceStatus::Running, "inst").is_ok());
+    }
+
+    #[test]
+    fn test_validate_stoppable_checked_out_ok() {
+        assert!(validate_stoppable(&InstanceStatus::CheckedOut, "inst").is_ok());
+    }
+
+    #[test]
+    fn test_validate_stoppable_idle_ok() {
+        assert!(validate_stoppable(&InstanceStatus::Idle, "inst").is_ok());
+    }
+
+    #[test]
+    fn test_validate_stoppable_stopped_errors() {
+        let err = validate_stoppable(&InstanceStatus::Stopped, "inst")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("already stopped"));
+    }
+
+    #[test]
+    fn test_validate_stoppable_provisioning_errors() {
+        let err = validate_stoppable(&InstanceStatus::Provisioning, "inst")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("currently"));
+    }
+
+    #[test]
+    fn test_validate_stoppable_assigning_errors() {
+        let err = validate_stoppable(&InstanceStatus::Assigning, "inst")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("currently"));
+    }
+
+    #[test]
+    fn test_validate_stoppable_starting_errors() {
+        let err = validate_stoppable(&InstanceStatus::Starting, "inst")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("currently"));
+    }
+
+    #[test]
+    fn test_validate_stoppable_stopping_errors() {
+        let err = validate_stoppable(&InstanceStatus::Stopping, "inst")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("currently"));
+    }
+
+    // --- kill_instance_socat_processes tests ---
+
+    #[tokio::test]
+    async fn test_kill_socat_clears_pids() {
+        let state = test_state();
+        let db = state.db.lock().await;
+        db.insert_instance(&make_instance("inst", "proj", InstanceStatus::Running))
+            .unwrap();
+        db.insert_port_allocation(
+            "proj",
+            "inst",
+            &coast_core::types::PortMapping {
+                logical_name: "web".to_string(),
+                canonical_port: 3000,
+                dynamic_port: 50000,
+                is_primary: false,
+            },
+        )
+        .unwrap();
+        db.insert_port_allocation(
+            "proj",
+            "inst",
+            &coast_core::types::PortMapping {
+                logical_name: "api".to_string(),
+                canonical_port: 8080,
+                dynamic_port: 50001,
+                is_primary: false,
+            },
+        )
+        .unwrap();
+        // Use PID values that won't exist (ESRCH → treated as success by kill_socat)
+        db.update_socat_pid("proj", "inst", "web", Some(4_194_304))
+            .unwrap();
+        db.update_socat_pid("proj", "inst", "api", Some(4_194_305))
+            .unwrap();
+
+        kill_instance_socat_processes(&db, "proj", "inst").unwrap();
+
+        let allocs = db.get_port_allocations("proj", "inst").unwrap();
+        for alloc in &allocs {
+            assert!(
+                alloc.socat_pid.is_none(),
+                "pid should be cleared for {}",
+                alloc.logical_name
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_kill_socat_no_pids_is_noop() {
+        let state = test_state();
+        let db = state.db.lock().await;
+        db.insert_instance(&make_instance("inst", "proj", InstanceStatus::Running))
+            .unwrap();
+        db.insert_port_allocation(
+            "proj",
+            "inst",
+            &coast_core::types::PortMapping {
+                logical_name: "web".to_string(),
+                canonical_port: 3000,
+                dynamic_port: 50000,
+                is_primary: false,
+            },
+        )
+        .unwrap();
+
+        // No socat PIDs set — should be a no-op
+        kill_instance_socat_processes(&db, "proj", "inst").unwrap();
+
+        let allocs = db.get_port_allocations("proj", "inst").unwrap();
+        assert!(allocs[0].socat_pid.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_kill_socat_no_allocations_is_noop() {
+        let state = test_state();
+        let db = state.db.lock().await;
+        db.insert_instance(&make_instance("inst", "proj", InstanceStatus::Running))
+            .unwrap();
+
+        // No port allocations at all — should be a no-op
+        kill_instance_socat_processes(&db, "proj", "inst").unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- Extracted `validate_stoppable` — pure function that checks if an instance status allows stopping
- Extracted `kill_instance_socat_processes` — kills socat PIDs and clears them in the DB
- Updated `handle` to call both helpers instead of inline logic
- Added 11 unit tests (8 for validation, 3 for socat cleanup)
- `#[allow(clippy::cognitive_complexity, clippy::too_many_lines)]` kept on `handle` — still triggers both lints after extraction (follow-up ticket)

## What was there before

`handle` was ~220 lines with status validation (lines 64-88) and socat cleanup (lines 200-216) inlined. The status checks were a chain of `if` statements comparing against individual `InstanceStatus` variants.

## What changed

Single file: `coast-daemon/src/handlers/stop.rs`

**Extracted functions:**

| Function | Type | What it does |
|---|---|---|
| `validate_stoppable(status, name)` | Pure, sync | Returns `Ok` for Running/CheckedOut/Idle, `Err` for Stopped and transitional states |
| `kill_instance_socat_processes(db, project, name)` | Sync | Iterates port allocations, kills socat PIDs, clears them in DB |

## Deviations from ticket suggestions

| Ticket suggested | What we did | Why |
|---|---|---|
| `Idle` grouped with `Enqueued` (not stoppable) | `Idle` grouped with `Running`/`CheckedOut` (stoppable) | Original code never rejected `Idle` — it fell through to the stoppable path. `coast archive` depends on this: `handle_archive` calls `stop::handle` for `Idle` instances. Rejecting `Idle` broke `test_handle_archive_stops_only_running_checked_out_and_idle_instances` (expected 3 stopped, got 2). Fixed by preserving the original behavior. |
| `kill_instance_socat_processes` as `async fn` | Made it `fn` (sync) | All operations inside are synchronous — DB reads via `StateDb` and process signals via `kill_socat`. `StateDb` is not `Send`, so marking the function `async` causes compilation errors. The ticket's suggestion was reasonable but doesn't work with the current type constraints. |

## Test plan

### Run new tests
```bash
# 17 tests pass (6 existing + 11 new)
cargo test -p coast-daemon -- stop::tests
```

### Verify archive tests still pass
```bash
# This test caught the Idle behavioral regression — must pass
cargo test -p coast-daemon -- archive
```

### Run lint and full tests
```bash
make lint    # zero warnings
make test    # all pass
```

### Verify behavior is unchanged
```bash
# coast stop should work for Running, CheckedOut, and Idle instances
# coast stop should error for Stopped and transitional states
# coast archive should stop all Running + CheckedOut + Idle instances
```

Closes #122