### PR TITLE
[jrs] add wsl support and fix install script

### DIFF
--- a/coast-cli/src/commands/daemon.rs
+++ b/coast-cli/src/commands/daemon.rs
@@ -539,7 +539,47 @@ fn ensure_registered_daemon_command(
     }
 }
 
+fn running_in_wsl() -> bool {
+    if std::env::var_os("WSL_DISTRO_NAME").is_some() || std::env::var_os("WSL_INTEROP").is_some() {
+        return true;
+    }
+    std::fs::read_to_string("/proc/version")
+        .map(|v| v.to_ascii_lowercase().contains("microsoft"))
+        .unwrap_or(false)
+}
+
+fn systemctl_available() -> bool {
+    std::process::Command::new("systemctl")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok()
+}
+
 fn run_ensure_registered_daemon(platform: InstallPlatform, registration_path: &Path) -> Result<()> {
+    if platform == InstallPlatform::Linux && !systemctl_available() {
+        let wsl_hint = if running_in_wsl() {
+            "\n\n  To enable systemd in WSL, add to /etc/wsl.conf:\n    \
+             [boot]\n    \
+             systemd=true\n  \
+             Then restart WSL: wsl --shutdown (from PowerShell)\n"
+        } else {
+            ""
+        };
+
+        eprintln!(
+            "{} systemctl is not available — the systemd unit was written to\n  \
+             {} but could not be enabled.{}\n\n  \
+             Starting the daemon directly instead...",
+            "warning:".yellow().bold(),
+            registration_path.display(),
+            wsl_hint,
+        );
+
+        return Ok(());
+    }
+
     let command = ensure_registered_daemon_command(platform, registration_path);
     let status = std::process::Command::new(command.program)
         .args(&command.args)
@@ -641,7 +681,8 @@ pub fn generate_systemd_unit(coastd_path: &str) -> String {
 async fn execute_install() -> Result<()> {
     let platform = current_install_platform()?;
     let registration_path = install_registration_path(platform)?;
-    let plan = build_install_plan(registration_path.exists(), daemon_status()?.running);
+    let status = daemon_status()?;
+    let plan = build_install_plan(registration_path.exists(), status.running);
     let coastd = resolve_coastd_path();
     let coastd_str = coastd.to_string_lossy();
     let coast_dir = dirs::home_dir()
@@ -662,8 +703,16 @@ async fn execute_install() -> Result<()> {
         write_install_registration(platform, &registration_path, &coastd_str, &log_dir)?;
     }
 
-    if plan.ensure_running {
+    let needs_direct_start = if plan.ensure_running {
+        let no_systemctl = platform == InstallPlatform::Linux && !systemctl_available();
         run_ensure_registered_daemon(platform, &registration_path)?;
+        no_systemctl
+    } else {
+        false
+    };
+
+    if needs_direct_start && !daemon_status()?.running {
+        execute_start().await?;
     }
 
     if plan.write_registration {

--- a/dindind/lib/base.Dockerfile
+++ b/dindind/lib/base.Dockerfile
@@ -1,0 +1,58 @@
+# Shared base image for DinDinD integration test scenarios.
+# Provides Ubuntu + Docker CE + Coast dependencies.
+#
+# Build args:
+#   DISTRO          -- base image (default: ubuntu:22.04)
+#   EXTRA_PACKAGES  -- space-separated list of additional apt packages
+ARG DISTRO=ubuntu:22.04
+FROM ${DISTRO}
+
+ARG EXTRA_PACKAGES=""
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release \
+    bash \
+    git \
+    socat \
+    sudo \
+    iptables \
+    ${EXTRA_PACKAGES} \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Docker CE from the official repository
+RUN install -m 0755 -d /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+     | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+  && chmod a+r /etc/apt/keyrings/docker.gpg \
+  && echo \
+       "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+       https://download.docker.com/linux/ubuntu \
+       $(lsb_release -cs) stable" \
+     > /etc/apt/sources.list.d/docker.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+       docker-ce \
+       docker-ce-cli \
+       containerd.io \
+       docker-compose-plugin \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js (LTS)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+  && apt-get install -y --no-install-recommends nodejs \
+  && rm -rf /var/lib/apt/lists/*
+
+# Non-root user matching typical WSL/Linux desktop setup
+RUN useradd -m -s /bin/bash testuser \
+  && usermod -aG docker testuser \
+  && echo "testuser ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+COPY lib/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+VOLUME /var/lib/docker
+ENTRYPOINT ["entrypoint.sh"]

--- a/dindind/lib/entrypoint.sh
+++ b/dindind/lib/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Shared entrypoint for DinDinD test containers.
+# Starts the Docker daemon (via sudo if non-root), waits for readiness,
+# then either runs the supplied command or drops to an interactive shell.
+set -eu
+
+DOCKER_READY_TIMEOUT="${DOCKER_READY_TIMEOUT:-60}"
+DOCKERD_LOG="/tmp/dockerd.log"
+
+echo "==> Starting Docker daemon..."
+if [ "$(id -u)" -eq 0 ]; then
+  dockerd --storage-driver=overlay2 > "$DOCKERD_LOG" 2>&1 &
+else
+  sudo dockerd --storage-driver=overlay2 > "$DOCKERD_LOG" 2>&1 &
+fi
+DOCKERD_PID=$!
+
+elapsed=0
+while ! docker info >/dev/null 2>&1; do
+  if ! kill -0 "$DOCKERD_PID" 2>/dev/null && ! sudo kill -0 "$DOCKERD_PID" 2>/dev/null; then
+    echo "error: dockerd exited unexpectedly. Last 20 lines of log:"
+    tail -20 "$DOCKERD_LOG"
+    exit 1
+  fi
+  if [ "$elapsed" -ge "$DOCKER_READY_TIMEOUT" ]; then
+    echo "error: Docker daemon did not become ready within ${DOCKER_READY_TIMEOUT}s"
+    tail -20 "$DOCKERD_LOG"
+    exit 1
+  fi
+  sleep 1
+  elapsed=$((elapsed + 1))
+done
+
+echo "==> Docker daemon ready (${elapsed}s)"
+
+if [ $# -gt 0 ]; then
+  exec "$@"
+else
+  exec bash -l
+fi

--- a/dindind/lib/test-local-build.sh
+++ b/dindind/lib/test-local-build.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Test Coast install from locally-built binaries.
+# Expects the Coast repo mounted read-only at /coast-repo with
+# pre-built release binaries in target/release/.
+#
+# Usage (inside a DinDinD container):
+#   /test-scripts/test-local-build.sh
+set -euo pipefail
+
+COAST_REPO="${COAST_REPO:-/coast-repo}"
+INSTALL_DIR="${HOME}/.coast/bin"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+die() { printf "${RED}error:${RESET} %s\n" "$1" >&2; exit 1; }
+
+for bin in coast coastd; do
+  src="${COAST_REPO}/target/release/${bin}"
+  [ -f "$src" ] || die "Binary not found: ${src} -- build the project first (cargo build --release)"
+done
+
+echo "==> Installing local binaries to ${INSTALL_DIR}..."
+mkdir -p "$INSTALL_DIR"
+cp "${COAST_REPO}/target/release/coast"  "${INSTALL_DIR}/coast"
+cp "${COAST_REPO}/target/release/coastd" "${INSTALL_DIR}/coastd"
+chmod 755 "${INSTALL_DIR}/coast" "${INSTALL_DIR}/coastd"
+
+export PATH="${INSTALL_DIR}:${PATH}"
+
+echo "==> Verifying..."
+echo "  coast:  $(command -v coast)"
+echo "  coastd: $(command -v coastd)"
+coast --version 2>/dev/null || true
+
+echo ""
+echo "==> Testing coast daemon install..."
+if coast daemon install 2>&1; then
+  printf "${GREEN}coast daemon install succeeded${RESET}\n"
+else
+  printf "${RED}coast daemon install failed${RESET}\n"
+fi
+
+echo ""
+echo "==> Checking binary path resolution..."
+coast_dir="$(dirname "$(readlink -f "$(command -v coast)")")"
+coastd_dir="$(dirname "$(readlink -f "$(command -v coastd)")")"
+echo "  coast dir:  ${coast_dir}"
+echo "  coastd dir: ${coastd_dir}"
+
+if [ "$coast_dir" = "$coastd_dir" ]; then
+  printf "${GREEN}Binaries co-located${RESET}\n"
+else
+  printf "${RED}Binaries in different directories${RESET}\n"
+  exit 1
+fi

--- a/dindind/matrix.sh
+++ b/dindind/matrix.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Matrix definition and runner for DinDinD integration tests.
+#
+# Scenarios define the platform/environment.
+# Depths define how far into the Docker nesting we test:
+#   install  -- just the install script (no inner Docker needed)
+#   daemon   -- install + coast daemon install (needs inner Docker)
+#   run      -- install + daemon + coast run (DinDinD)
+#   e2e      -- full compose stack inside Coast containers (DinDinDinD, future)
+#
+# Usage (sourced by run.sh):
+#   source matrix.sh
+#   matrix_run [scenario] [depth]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# Matrix axes -- extend these arrays to add new scenarios or depth levels
+# ---------------------------------------------------------------------------
+SCENARIOS=(wsl-ubuntu)
+DEPTHS=(install daemon)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+IMAGE_PREFIX="coast-dindind"
+
+scenario_dir() {
+  echo "${SCRIPT_DIR}/scenarios/$1"
+}
+
+image_tag() {
+  echo "${IMAGE_PREFIX}-$1"
+}
+
+build_scenario() {
+  local scenario="$1"
+  local tag
+  tag="$(image_tag "$scenario")"
+  local sdir
+  sdir="$(scenario_dir "$scenario")"
+
+  if [ ! -f "${sdir}/Dockerfile" ]; then
+    echo "error: no Dockerfile for scenario '${scenario}'" >&2
+    return 1
+  fi
+
+  echo "==> Building image ${tag} for scenario ${scenario}..."
+  docker build \
+    -t "$tag" \
+    -f "${sdir}/Dockerfile" \
+    "$SCRIPT_DIR"
+}
+
+run_scenario() {
+  local scenario="$1"
+  local depth="$2"
+  local tag
+  tag="$(image_tag "$scenario")"
+  local sdir
+  sdir="$(scenario_dir "$scenario")"
+
+  local test_script="${sdir}/test-install.sh"
+  if [ ! -f "$test_script" ]; then
+    echo "error: missing ${test_script}" >&2
+    return 1
+  fi
+
+  local container_name="${IMAGE_PREFIX}-${scenario}-${depth}-$$"
+
+  echo "==> Running scenario=${scenario} depth=${depth} ..."
+  docker run --rm \
+    --privileged \
+    --name "$container_name" \
+    -e "DINDIND_DEPTH=${depth}" \
+    -v "${SCRIPT_DIR}/..:/coast-repo:ro" \
+    "$tag" \
+    bash -l -c "/test-scripts/test-install.sh"
+}
+
+run_interactive() {
+  local scenario="$1"
+  local tag
+  tag="$(image_tag "$scenario")"
+
+  echo "==> Interactive shell for scenario=${scenario}"
+  docker run --rm -it \
+    --privileged \
+    -v "${SCRIPT_DIR}/..:/coast-repo:ro" \
+    "$tag"
+}
+
+# ---------------------------------------------------------------------------
+# Matrix runner
+# ---------------------------------------------------------------------------
+
+matrix_run() {
+  local filter_scenario="${1:-}"
+  local filter_depth="${2:-}"
+
+  local pass=0
+  local fail=0
+  local skip=0
+  local results=()
+
+  for scenario in "${SCENARIOS[@]}"; do
+    if [ -n "$filter_scenario" ] && [ "$filter_scenario" != "$scenario" ]; then
+      continue
+    fi
+
+    build_scenario "$scenario"
+
+    for depth in "${DEPTHS[@]}"; do
+      if [ -n "$filter_depth" ] && [ "$filter_depth" != "$depth" ]; then
+        continue
+      fi
+
+      if run_scenario "$scenario" "$depth"; then
+        results+=("PASS  ${scenario}  ${depth}")
+        pass=$((pass + 1))
+      else
+        results+=("FAIL  ${scenario}  ${depth}")
+        fail=$((fail + 1))
+      fi
+    done
+  done
+
+  echo ""
+  echo "=============================="
+  echo "  DinDinD Matrix Results"
+  echo "=============================="
+  printf "%-6s %-20s %s\n" "RESULT" "SCENARIO" "DEPTH"
+  printf "%-6s %-20s %s\n" "------" "--------" "-----"
+  for r in "${results[@]}"; do
+    echo "$r"
+  done
+  echo ""
+  echo "Pass: ${pass}  Fail: ${fail}  Skip: ${skip}"
+
+  [ "$fail" -eq 0 ]
+}

--- a/dindind/run.sh
+++ b/dindind/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Top-level runner for DinDinD integration tests.
+#
+# Usage:
+#   ./run.sh                        Run full matrix
+#   ./run.sh wsl-ubuntu             Run single scenario, all depths
+#   ./run.sh wsl-ubuntu install     Run single scenario at specific depth
+#   ./run.sh wsl-ubuntu shell       Interactive shell in the scenario container
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/matrix.sh"
+
+build_base() {
+  echo "==> Building shared base image..."
+  docker build \
+    -t coast-dindind-base \
+    -f "${SCRIPT_DIR}/lib/base.Dockerfile" \
+    "$SCRIPT_DIR"
+}
+
+SCENARIO="${1:-}"
+DEPTH="${2:-}"
+
+build_base
+
+if [ "$DEPTH" = "shell" ]; then
+  build_scenario "$SCENARIO"
+  run_interactive "$SCENARIO"
+elif [ -n "$SCENARIO" ]; then
+  matrix_run "$SCENARIO" "$DEPTH"
+else
+  matrix_run
+fi

--- a/dindind/scenarios/wsl-ubuntu/Dockerfile
+++ b/dindind/scenarios/wsl-ubuntu/Dockerfile
@@ -1,0 +1,18 @@
+# WSL2 Ubuntu simulation for reproducing issue #130.
+# Extends the shared base image with WSL environment variables so that
+# Coast's WSL detection (env vars + /proc/version) triggers.
+FROM coast-dindind-base AS base
+
+# Simulate WSL2 environment variables
+ENV WSL_DISTRO_NAME=Ubuntu
+ENV WSL_INTEROP=/run/WSL/1_interop
+ENV SHELL=/bin/bash
+
+# Copy scenario test scripts
+COPY scenarios/wsl-ubuntu/test-install.sh /test-scripts/test-install.sh
+COPY scenarios/wsl-ubuntu/env.sh          /test-scripts/env.sh
+COPY lib/test-local-build.sh              /test-scripts/test-local-build.sh
+RUN chmod +x /test-scripts/*.sh
+
+USER testuser
+WORKDIR /home/testuser

--- a/dindind/scenarios/wsl-ubuntu/env.sh
+++ b/dindind/scenarios/wsl-ubuntu/env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Scenario-specific environment overrides for WSL Ubuntu simulation.
+# Sourced by test scripts before running checks.
+
+export WSL_DISTRO_NAME="${WSL_DISTRO_NAME:-Ubuntu}"
+export WSL_INTEROP="${WSL_INTEROP:-/run/WSL/1_interop}"

--- a/dindind/scenarios/wsl-ubuntu/test-install.sh
+++ b/dindind/scenarios/wsl-ubuntu/test-install.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# WSL Ubuntu install test -- reproduces issue #130.
+# Runs inside the DinDinD container as testuser.
+#
+# Controlled by DINDIND_DEPTH env var:
+#   install  -- test the install script only
+#   daemon   -- install + coast daemon install
+#   run      -- install + daemon + coast run (future)
+#   e2e      -- full stack (future)
+set -euo pipefail
+
+DEPTH="${DINDIND_DEPTH:-install}"
+PASS=0
+FAIL=0
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+source /test-scripts/env.sh
+
+check() {
+  local name="$1"
+  shift
+  printf "${BOLD}--- TEST: %s${RESET}\n" "$name"
+  if "$@"; then
+    printf "${GREEN}PASS${RESET}: %s\n\n" "$name"
+    PASS=$((PASS + 1))
+  else
+    printf "${RED}FAIL${RESET}: %s\n\n" "$name"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+cleanup_install() {
+  rm -rf "${HOME}/.coast"
+  # Remove PATH line from shell rc files
+  for rc in "${HOME}/.bashrc" "${HOME}/.bash_profile" "${HOME}/.zshrc"; do
+    if [ -f "$rc" ]; then
+      grep -v '.coast/bin' "$rc" > "${rc}.tmp" 2>/dev/null && mv "${rc}.tmp" "$rc" || true
+    fi
+  done
+  hash -r 2>/dev/null || true
+}
+
+# =========================================================================
+# Depth: install
+# =========================================================================
+
+test_eval_install() {
+  cleanup_install
+  echo "Running: eval \"\$(curl -fsSL https://coasts.dev/install)\""
+  eval "$(curl -fsSL https://coasts.dev/install)" 2>&1 || true
+
+  if command -v coast >/dev/null 2>&1; then
+    echo "coast found at: $(command -v coast)"
+    echo "coastd location: $(dirname "$(command -v coast)")/coastd"
+    [ -x "$(dirname "$(command -v coast)")/coastd" ]
+  else
+    echo "coast not found on PATH after eval install"
+    echo "PATH=${PATH}"
+    ls -la "${HOME}/.coast/bin/" 2>/dev/null || echo "~/.coast/bin/ does not exist"
+    return 1
+  fi
+}
+
+test_pipe_install() {
+  cleanup_install
+  echo "Running: curl -fsSL https://coasts.dev/install | sh"
+  curl -fsSL https://coasts.dev/install | sh 2>&1 || true
+
+  echo ""
+  echo "Checking if coast is on PATH in current shell..."
+  if command -v coast >/dev/null 2>&1; then
+    echo "coast found at: $(command -v coast) (unexpected -- pipe install usually loses PATH)"
+  else
+    echo "coast NOT on PATH (expected with pipe install)"
+  fi
+
+  echo ""
+  echo "Checking if binaries exist at expected location..."
+  if [ -x "${HOME}/.coast/bin/coast" ] && [ -x "${HOME}/.coast/bin/coastd" ]; then
+    echo "Binaries present at ~/.coast/bin/ -- install succeeded, PATH just didn't stick"
+    echo "  coast:  $(ls -la "${HOME}/.coast/bin/coast")"
+    echo "  coastd: $(ls -la "${HOME}/.coast/bin/coastd")"
+    return 0
+  else
+    echo "Binaries NOT found at ~/.coast/bin/"
+    ls -la "${HOME}/.coast/bin/" 2>/dev/null || echo "~/.coast/bin/ does not exist"
+    return 1
+  fi
+}
+
+test_path_in_bashrc() {
+  cleanup_install
+  eval "$(curl -fsSL https://coasts.dev/install)" 2>&1 || true
+
+  if grep -q '.coast/bin' "${HOME}/.bashrc" 2>/dev/null; then
+    echo "PATH entry found in ~/.bashrc"
+    grep '.coast/bin' "${HOME}/.bashrc"
+    return 0
+  else
+    echo "PATH entry NOT found in ~/.bashrc"
+    echo "Contents of ~/.bashrc:"
+    cat "${HOME}/.bashrc" 2>/dev/null || echo "(file does not exist)"
+    return 1
+  fi
+}
+
+test_binary_paths_match() {
+  cleanup_install
+  eval "$(curl -fsSL https://coasts.dev/install)" 2>&1 || true
+  export PATH="${HOME}/.coast/bin:${PATH}"
+
+  local coast_path coastd_path coast_dir coastd_dir
+  coast_path="$(command -v coast 2>/dev/null || true)"
+  coastd_path="$(command -v coastd 2>/dev/null || true)"
+
+  if [ -z "$coast_path" ] || [ -z "$coastd_path" ]; then
+    echo "Could not find both binaries on PATH"
+    echo "  coast:  ${coast_path:-NOT FOUND}"
+    echo "  coastd: ${coastd_path:-NOT FOUND}"
+    return 1
+  fi
+
+  coast_dir="$(dirname "$(readlink -f "$coast_path")")"
+  coastd_dir="$(dirname "$(readlink -f "$coastd_path")")"
+
+  echo "coast  resolved to: ${coast_dir}/coast"
+  echo "coastd resolved to: ${coastd_dir}/coastd"
+
+  if [ "$coast_dir" = "$coastd_dir" ]; then
+    echo "Both binaries are in the same directory"
+    return 0
+  else
+    echo "MISMATCH: coast and coastd are in different directories"
+    return 1
+  fi
+}
+
+check "eval install puts coast on PATH"        test_eval_install
+check "pipe install deposits binaries"          test_pipe_install
+check "install adds PATH to .bashrc"            test_path_in_bashrc
+check "coast and coastd are co-located"         test_binary_paths_match
+
+# =========================================================================
+# Depth: daemon
+# =========================================================================
+
+if [ "$DEPTH" = "daemon" ] || [ "$DEPTH" = "run" ] || [ "$DEPTH" = "e2e" ]; then
+
+  test_daemon_install() {
+    cleanup_install
+    eval "$(curl -fsSL https://coasts.dev/install)" 2>&1 || true
+    export PATH="${HOME}/.coast/bin:${PATH}"
+
+    echo "Running: coast daemon install"
+    if coast daemon install 2>&1; then
+      echo "coast daemon install succeeded"
+    else
+      local ec=$?
+      echo "coast daemon install failed (exit ${ec})"
+      echo ""
+      echo "Checking systemd availability..."
+      if command -v systemctl >/dev/null 2>&1; then
+        echo "systemctl is available"
+        systemctl --user status coastd 2>&1 || true
+      else
+        echo "systemctl NOT available (common in WSL without systemd enabled)"
+      fi
+      return 1
+    fi
+  }
+
+  test_systemd_unit_path() {
+    local unit_path="${HOME}/.config/systemd/user/coastd.service"
+    if [ ! -f "$unit_path" ]; then
+      echo "systemd unit not found at ${unit_path}"
+      return 1
+    fi
+
+    echo "systemd unit contents:"
+    cat "$unit_path"
+    echo ""
+
+    local exec_start
+    exec_start="$(grep '^ExecStart=' "$unit_path" | cut -d= -f2 | awk '{print $1}')"
+    echo "ExecStart binary: ${exec_start}"
+
+    if [ -x "$exec_start" ]; then
+      echo "Binary at ExecStart path exists and is executable"
+      return 0
+    else
+      echo "Binary at ExecStart path does NOT exist or is not executable"
+      ls -la "$exec_start" 2>/dev/null || echo "(file not found)"
+      return 1
+    fi
+  }
+
+  check "coast daemon install"                  test_daemon_install
+  check "systemd unit points to valid binary"   test_systemd_unit_path
+fi
+
+# =========================================================================
+# Depth: run (future)
+# =========================================================================
+
+if [ "$DEPTH" = "run" ] || [ "$DEPTH" = "e2e" ]; then
+  echo "${YELLOW}==> Depth 'run' tests not yet implemented${RESET}"
+fi
+
+# =========================================================================
+# Depth: e2e (future)
+# =========================================================================
+
+if [ "$DEPTH" = "e2e" ]; then
+  echo "${YELLOW}==> Depth 'e2e' tests not yet implemented${RESET}"
+fi
+
+# =========================================================================
+# Summary
+# =========================================================================
+
+echo ""
+echo "=============================="
+echo "  Scenario: wsl-ubuntu"
+echo "  Depth:    ${DEPTH}"
+echo "=============================="
+echo "  Pass: ${PASS}"
+echo "  Fail: ${FAIL}"
+echo ""
+
+[ "$FAIL" -eq 0 ]

--- a/external/install.sh
+++ b/external/install.sh
@@ -47,6 +47,17 @@ esac
 PLATFORM="${OS}-${ARCH}"
 info "Detected platform: ${PLATFORM}"
 
+# --- Detect WSL ---
+IS_WSL=false
+if [ -n "${WSL_DISTRO_NAME:-}" ] || [ -n "${WSL_INTEROP:-}" ]; then
+  IS_WSL=true
+elif [ -f /proc/version ] && grep -qi microsoft /proc/version 2>/dev/null; then
+  IS_WSL=true
+fi
+if [ "$IS_WSL" = true ]; then
+  info "WSL detected (${WSL_DISTRO_NAME:-unknown distro})"
+fi
+
 # --- Find latest release with downloadable assets ---
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "${TMPDIR}"' EXIT
@@ -167,15 +178,82 @@ if ! command -v socat >/dev/null 2>&1; then
   fi
 fi
 
+# --- Check Docker ---
+if ! command -v docker >/dev/null 2>&1; then
+  warn "Docker is not installed or not on PATH"
+  if [ "$IS_WSL" = true ]; then
+    printf "  Coast requires Docker Engine. Install it with:\n"
+    printf "    ${BOLD}sudo apt-get update && sudo apt-get install -y docker-ce docker-ce-cli containerd.io${RESET}\n"
+    printf "  Or install Docker Desktop for Windows and enable the WSL 2 backend.\n"
+  elif [ "$OS" = "darwin" ]; then
+    printf "  Install Docker Desktop: ${BOLD}https://www.docker.com/products/docker-desktop${RESET}\n"
+  else
+    printf "  Install Docker Engine: ${BOLD}https://docs.docker.com/engine/install/${RESET}\n"
+  fi
+fi
+
+# --- Detect stale coast binaries at other PATH locations ---
+STALE_COAST=""
+ORIGINAL_PATH="${PATH#*${INSTALL_DIR}:}"
+if [ "$ORIGINAL_PATH" = "$PATH" ]; then
+  ORIGINAL_PATH="${PATH}"
+fi
+OLD_IFS="$IFS"
+IFS=":"
+for dir in $ORIGINAL_PATH; do
+  if [ "$dir" = "${INSTALL_DIR}" ]; then
+    continue
+  fi
+  if [ -e "${dir}/coast" ]; then
+    STALE_COAST="${dir}/coast"
+    break
+  fi
+done
+IFS="$OLD_IFS"
+
+if [ -n "${STALE_COAST}" ]; then
+  warn "Found a stale coast binary at ${BOLD}${STALE_COAST}${RESET}"
+  printf "  This will shadow the newly installed version and likely cause errors.\n"
+  printf "  Remove it with: ${BOLD}rm ${STALE_COAST}${RESET}\n"
+  if [ -e "${STALE_COAST%coast}coastd" ]; then
+    printf "                  ${BOLD}rm ${STALE_COAST%coast}coastd${RESET}\n"
+  fi
+  printf "\n"
+fi
+
 # --- Verify ---
 if command -v coast >/dev/null 2>&1; then
   INSTALLED_VERSION=$(coast --version 2>/dev/null | head -1 | sed 's/coast /v/' || echo "unknown")
   printf "\n${GREEN}Done!${RESET} Coast installed successfully: ${BOLD}${INSTALLED_VERSION}${RESET}\n"
-  printf "  Run ${BOLD}coast help${RESET} to get started\n\n"
 else
-  warn "coast was installed to ${INSTALL_DIR} but is not on your PATH"
-  printf "  Restart your terminal, then run: ${BOLD}coast help${RESET}\n\n"
+  warn "coast was installed to ${INSTALL_DIR} but is not on your PATH yet"
+  printf "  Restart your terminal or run: ${BOLD}source ${SHELL_RC_FILE:-~/.bashrc}${RESET}\n"
 fi
+
+# --- Next steps ---
+printf "\n${BOLD}Next steps:${RESET}\n"
+if [ -n "${STALE_COAST}" ]; then
+  printf "  ${RED}0. Remove the stale binary:${RESET} ${BOLD}rm ${STALE_COAST}${RESET}\n"
+fi
+printf "  1. ${BOLD}coast daemon install${RESET}    Register the daemon to start at login\n"
+
+if [ "$IS_WSL" = true ]; then
+  HAS_SYSTEMD=false
+  if command -v systemctl >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; then
+    HAS_SYSTEMD=true
+  fi
+  if [ "$HAS_SYSTEMD" = false ]; then
+    printf "\n${YELLOW}  WSL note:${RESET} coast daemon install requires systemd.\n"
+    printf "  If it fails, enable systemd in WSL by adding to ${BOLD}/etc/wsl.conf${RESET}:\n"
+    printf "    [boot]\n"
+    printf "    systemd=true\n"
+    printf "  Then restart WSL: ${BOLD}wsl --shutdown${RESET} (from PowerShell)\n"
+    printf "\n  Alternatively, start the daemon manually each session:\n"
+    printf "    ${BOLD}coast daemon start${RESET}\n"
+  fi
+fi
+
+printf "  2. ${BOLD}coast help${RESET}              See all available commands\n\n"
 ) >&2
 
 # Make coast available in the current shell (works when invoked via eval)


### PR DESCRIPTION
fixes #130 - @GregPeden  reported install was broken on ubuntu in wsl2. reproduced it in a dind test environment and found two issues:

if you had a stale coast binary at ~/.local/bin from a previous install, it would shadow the new one at ~/.coast/bin and you'd get a confusing "no such file or directory" error. the install script now detects this and tells you to remove it.

coast daemon install would hard crash on wsl when systemctl isn't available (which is the default). now it writes the systemd unit file but falls back to starting the daemon directly instead of blowing up.

also added wsl detection to the install script so it prints helpful guidance about enabling systemd and checking docker.

the dindind/ directory is a test harness that spins up a privileged ubuntu container with docker inside it to simulate wsl2. structured as a matrix so we can add more scenarios and deeper nesting levels later.