### PR TITLE
refactor: extract worktree detection phases from detect_worktree_path

### DIFF
--- a/coast-daemon/src/handlers/assign/services.rs
+++ b/coast-daemon/src/handlers/assign/services.rs
@@ -254,9 +254,7 @@ async fn detect_worktree_path(
     let step_t = std::time::Instant::now();
 
     // Phases 1–3: Search existing worktree directories.
-    if let Some((loc, phase)) =
-        find_existing_worktree(root, worktree_dirs, worktree_name).await
-    {
+    if let Some((loc, phase)) = find_existing_worktree(root, worktree_dirs, worktree_name).await {
         info!(elapsed_ms = step_t.elapsed().as_millis() as u64, wt_dir = %loc.wt_dir, phase, "resolved existing worktree");
         return Some(loc);
     }


### PR DESCRIPTION
## Summary

- Extracted `find_existing_worktree` (phases 1–3): searches local dirs by name, external dirs, then local dirs by branch name
- Extracted `fallback_worktree_path` (phases 4–5): tries git-detected worktree dir, falls back to default
- Extracted `default_worktree_location`: pure path construction helper
- Removed `#[allow(clippy::cognitive_complexity)]` — function now passes without suppression
- Added 7 unit tests for the new and existing pure functions

## What was there before

`detect_worktree_path` (line 247) had `#[allow(clippy::cognitive_complexity)]` with a comment "Linear phase chain — reads clearly top to bottom." The function was ~50 lines with 5 phases, each doing `if let Some` + `info!` + `return`. Clippy measured it at 42/30 cognitive complexity — the repeated pattern of option-check + structured logging with multiple fields was the main contributor.

## What changed

Single file: `coast-daemon/src/handlers/assign/services.rs`

| Function | Type | What it does |
|---|---|---|
| `find_existing_worktree(root, dirs, name)` | Async | Phases 1–3: searches local dirs by dirname, external dirs, local dirs by branch. Returns `(WorktreeLocation, &str)` with a phase label |
| `fallback_worktree_path(root, default_dir, name)` | Async | Phases 4–5: tries git-detected dir via `spawn_blocking`, falls back to default. Returns `(WorktreeLocation, &str)` |
| `default_worktree_location(root, dir, name)` | Pure, sync | Builds a `WorktreeLocation` from the default worktree directory |

`detect_worktree_path` is now a thin orchestrator: call `find_existing_worktree`, if None call `fallback_worktree_path`, log the result with the phase label. One caller (`docker_steps`, line 77), signature and return type unchanged.

### Logging preserved

The original logged per-phase messages like "resolved worktree by directory name (local)". The refactored version returns a `&'static str` phase label from each helper, logged as a structured `phase` field — same information, same granularity:
- `"directory name (local)"`, `"external dir"`, `"branch name (local)"`, `"git-detected"`, `"default"`

## Test plan

### Run new tests
```bash
# 7 new tests pass
cargo test -p coast-daemon -- handlers::assign::services::tests::test_try_git_detected
cargo test -p coast-daemon -- handlers::assign::services::tests::test_default_worktree_location
cargo test -p coast-daemon -- handlers::assign::services::tests::test_find_existing_worktree
```

### Verify suppression is removed
```bash
# Should return zero matches for detect_worktree_path
grep -n "cognitive_complexity" coast-daemon/src/handlers/assign/services.rs
```

### Run lint and full tests
```bash
cargo clippy --package coast-daemon --all-targets  # zero new warnings
cargo test -p coast-daemon                          # 909 tests pass
cargo test                                          # full workspace green
```

Closes #176