### PR TITLE
fix: fish shell support for install script

### DIFF
--- a/external/install.sh
+++ b/external/install.sh
@@ -256,8 +256,10 @@ fi
 printf "  2. ${BOLD}coast help${RESET}              See all available commands\n\n"
 ) >&2
 
-# Make coast available in the current shell (works when invoked via eval)
+# Make coast available in the current shell
+# bash/zsh: eval "$(curl ...)" runs this script directly, so export takes effect
+# fish: eval (curl ... | sh) pipes through sh, so printf output is captured and eval'd
 case "${SHELL:-}" in
   */fish) printf 'fish_add_path -gP "%s/.coast/bin"\n' "$HOME" ;;
-  *)      printf 'export PATH="%s/.coast/bin:${PATH}"\n' "$HOME" ;;
+  *)      export PATH="${HOME}/.coast/bin:${PATH}" ;;
 esac


### PR DESCRIPTION
## Summary
- Detect fish vs bash/zsh in the install script's eval output
- bash/zsh: direct `export PATH=...` (executed by `eval "$(curl ...)"`)
- fish: `printf` outputs `fish_add_path` to stdout (captured by `eval (curl ... | sh)`)

## Test plan
- [ ] `eval "$(curl -fsSL https://coasts.dev/install)"` in zsh — coast immediately available
- [ ] `eval (curl -fsSL https://coasts.dev/install | sh)` in fish — coast immediately available