### PR TITLE
Fix: Correct Makefile .PHONY declaration and README project structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include .env
 export
 
-.PHONY: lint fix test coverage coverage-text check fmt zip-projects unpack-projects watch \
+.PHONY: lint fix test coverage coverage-text coverage-lcov check zip-projects unpack-projects watch \
        docs-version docs-status translate translate-all doc-search doc-search-all \
        prune run-dind-integration
 

--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ coast/
   coast-core/         # Shared types, Coastfile parsing, protocol definitions
   coast-secrets/      # Secret extraction, encryption, keystore
   coast-docker/       # Docker API wrapper, DinD runtime, compose interaction
-  coast-git/          # Git worktree management
   coast-guard/        # Web UI (React + Vite), served by the daemon
   coast-i18n/         # i18n locale files for the CLI
+  coast-update/       # Update checking and installation
   scripts/            # Python build scripts (translation, search index generation)
   docs/               # User-facing documentation (English + translations)
   integrated-examples/  # Example projects and shell-based integration tests


### PR DESCRIPTION
## Summary
This PR fixes documentation inconsistencies in the Makefile and README.

## Changes

### 1. Makefile - Fix .PHONY declaration
- **Add**: `coverage-lcov` target was defined but missing from `.PHONY` declaration
- **Remove**: `fmt` target was listed in `.PHONY` but doesn't exist in the Makefile

The `.PHONY` declaration should include all targets that don't produce files. Having targets missing from `.PHONY` or listing non-existent targets are both inconsistencies that should be fixed.

### 2. README.md - Fix project structure documentation
- **Remove**: `coast-git/` - This directory is listed but doesn't exist in the repository. Git worktree management functionality appears to be part of other crates (likely coast-core).
- **Add**: `coast-update/` - This directory exists for update checking functionality but was not documented.

## Testing
- Verified all directories actually exist: `ls -la | grep coast`
- Confirmed `coast-git` doesn't exist in the repository
- Confirmed `coast-update` exists and has valid Cargo.toml

## Checklist
- [x] Changes are minimal and focused on documentation fixes
- [x] No code behavior changes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>