### PR TITLE
refactor: extract parse_image_ref and drain_pull_stream from dind::ensure_image to reduce cognitive complexity

### DIFF
--- a/coast-docker/src/dind.rs
+++ b/coast-docker/src/dind.rs
@@ -85,6 +85,46 @@ pub struct DindRuntime {
     docker: Docker,
 }
 
+/// Parse a Docker image reference into `(repo, tag)`.
+///
+/// Uses the last `:` as the separator. If no `:` is present, defaults tag to `"latest"`.
+fn parse_image_ref(image: &str) -> (String, String) {
+    if let Some((repo, tag)) = image.rsplit_once(':') {
+        (repo.to_string(), tag.to_string())
+    } else {
+        (image.to_string(), "latest".to_string())
+    }
+}
+
+/// Drain a `create_image` pull stream, logging progress and converting errors.
+async fn drain_pull_stream(
+    image: &str,
+    mut stream: impl futures_util::Stream<
+            Item = std::result::Result<bollard::models::CreateImageInfo, bollard::errors::Error>,
+        > + Unpin,
+) -> Result<()> {
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(info) => {
+                if let Some(ref status) = info.status {
+                    debug!(status = %status, "pull progress");
+                }
+            }
+            Err(e) => {
+                return Err(CoastError::Docker {
+                    message: format!(
+                        "Failed to pull image '{image}'. \
+                         Ensure you have network access and the image name is correct. \
+                         Error: {e}"
+                    ),
+                    source: Some(Box::new(e)),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
 impl DindRuntime {
     /// Create a new DinD runtime connected to the default Docker socket.
     pub fn new() -> Result<Self> {
@@ -100,9 +140,7 @@ impl DindRuntime {
     }
 
     /// Ensure a Docker image is available locally, pulling it if not found.
-    #[allow(clippy::cognitive_complexity)]
     async fn ensure_image(&self, image: &str) -> Result<()> {
-        // Check if the image already exists locally
         if self.docker.inspect_image(image).await.is_ok() {
             debug!(image = %image, "Image already available locally");
             return Ok(());
@@ -110,39 +148,15 @@ impl DindRuntime {
 
         info!(image = %image, "Pulling image (not found locally)");
 
-        // Parse image into repo and tag
-        let (repo, tag) = if let Some((r, t)) = image.rsplit_once(':') {
-            (r.to_string(), t.to_string())
-        } else {
-            (image.to_string(), "latest".to_string())
-        };
-
+        let (repo, tag) = parse_image_ref(image);
         let options = CreateImageOptions {
             from_image: repo,
             tag,
             ..Default::default()
         };
 
-        let mut stream = self.docker.create_image(Some(options), None, None);
-        while let Some(result) = stream.next().await {
-            match result {
-                Ok(info) => {
-                    if let Some(ref status) = info.status {
-                        debug!(status = %status, "pull progress");
-                    }
-                }
-                Err(e) => {
-                    return Err(CoastError::Docker {
-                        message: format!(
-                            "Failed to pull image '{image}'. \
-                             Ensure you have network access and the image name is correct. \
-                             Error: {e}"
-                        ),
-                        source: Some(Box::new(e)),
-                    });
-                }
-            }
-        }
+        let stream = self.docker.create_image(Some(options), None, None);
+        drain_pull_stream(image, stream).await?;
 
         info!(image = %image, "Image pulled successfully");
         Ok(())
@@ -1327,6 +1341,48 @@ mod tests {
                 .iter()
                 .any(|m| m.target.as_deref() == Some("/image-cache")),
             "non-propagation mounts should not appear in mounts"
+        );
+    }
+
+    #[test]
+    fn test_parse_image_ref_simple() {
+        assert_eq!(
+            parse_image_ref("alpine"),
+            ("alpine".to_string(), "latest".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_image_ref_with_tag() {
+        assert_eq!(
+            parse_image_ref("alpine:3.18"),
+            ("alpine".to_string(), "3.18".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_image_ref_registry_with_tag() {
+        assert_eq!(
+            parse_image_ref("registry.io/ns/img:tag"),
+            ("registry.io/ns/img".to_string(), "tag".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_image_ref_registry_port_no_tag() {
+        // rsplit_once splits at the only colon — known limitation of simple parsing.
+        // In practice, images with registry ports always include an explicit tag.
+        assert_eq!(
+            parse_image_ref("registry.io:5000/ns/img"),
+            ("registry.io".to_string(), "5000/ns/img".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_image_ref_registry_port_with_tag() {
+        assert_eq!(
+            parse_image_ref("registry.io:5000/ns/img:v1"),
+            ("registry.io:5000/ns/img".to_string(), "v1".to_string())
         );
     }
 }


### PR DESCRIPTION
## Summary

- Extracted `parse_image_ref` to parse Docker image references into `(repo, tag)`
- Extracted `drain_pull_stream` to consume the `create_image` pull stream with progress logging and error conversion
- Removed `#[allow(clippy::cognitive_complexity)]` — function now passes without suppression
- Added 5 unit tests for `parse_image_ref`

## What was there before

`ensure_image` (line 103) had `#[allow(clippy::cognitive_complexity)]`. The function was ~50 lines with image parsing, stream iteration, and error construction inlined. Clippy flagged it due to the `while let Some` + `match Ok/Err` + nested `if let Some` pattern inside the pull stream loop.

## What changed

Single file: `coast-docker/src/dind.rs`

| Function | Type | What it does |
|---|---|---|
| `parse_image_ref(image)` | Pure, sync | Parses `"repo:tag"` into `(repo, tag)` using `rsplit_once(':')`, defaults tag to `"latest"` if no colon. Extracted from lines 113–118 |
| `drain_pull_stream(image, stream)` | Async | Iterates the `create_image` stream, logs progress events, converts errors to `CoastError::Docker`. Extracted from lines 126–145 |

`ensure_image` is now: check local → parse ref → build options → pull → log success. One caller (internal to `DindRuntime`), signature and return type unchanged.

## Notes

- `parse_image_ref` uses `rsplit_once(':')` which splits at the last colon. For images like `registry.io:5000/ns/img` (registry port, no explicit tag), this produces `("registry.io", "5000/ns/img")` — same as the original code. In practice, registry-with-port images always include an explicit tag (e.g., `registry.io:5000/ns/img:v1`)
- `drain_pull_stream` takes `impl Stream + Unpin` to avoid naming the concrete bollard type

## Test plan

### Run new tests
```bash
# 5 new tests pass
cargo test -p coast-docker -- dind::tests::test_parse_image_ref
```

### Verify suppression is removed
```bash
# Should return zero matches
grep -n "cognitive_complexity" coast-docker/src/dind.rs
```

### Run lint and full tests
```bash
cargo clippy --package coast-docker --lib -- -D warnings  # zero new warnings
cargo test -p coast-docker                                  # all tests pass
make lint                                                   # clean
make test                                                   # all workspace tests pass
```

Closes #224