### PR TITLE
refactor: extract forward_event_to_socket and handle_inbound_ws_message from websocket::handle_socket to reduce cognitive complexity

### DIFF
--- a/coast-daemon/src/api/websocket.rs
+++ b/coast-daemon/src/api/websocket.rs
@@ -1,3 +1,4 @@
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
@@ -5,7 +6,10 @@ use axum::extract::State;
 use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::Router;
+use tokio::sync::broadcast::error::RecvError;
 use tracing::{debug, warn};
+
+use coast_core::protocol::CoastEvent;
 
 use crate::server::AppState;
 
@@ -17,7 +21,50 @@ async fn ws_handler(ws: WebSocketUpgrade, State(state): State<Arc<AppState>>) ->
     ws.on_upgrade(move |socket| handle_socket(socket, state))
 }
 
-#[allow(clippy::cognitive_complexity)]
+/// Serialize a bus event and send it to the WebSocket client.
+async fn forward_event_to_socket(
+    socket: &mut WebSocket,
+    event: Result<CoastEvent, RecvError>,
+) -> ControlFlow<()> {
+    match event {
+        Ok(coast_event) => match serde_json::to_string(&coast_event) {
+            Ok(json) => {
+                if socket.send(Message::Text(json.into())).await.is_err() {
+                    return ControlFlow::Break(());
+                }
+            }
+            Err(e) => {
+                warn!("failed to serialize event: {e}");
+            }
+        },
+        Err(RecvError::Lagged(n)) => {
+            warn!("websocket client lagged, skipped {n} events");
+        }
+        Err(RecvError::Closed) => {
+            return ControlFlow::Break(());
+        }
+    }
+    ControlFlow::Continue(())
+}
+
+/// Handle an inbound WebSocket message (Close, Ping/Pong, or ignore).
+async fn handle_inbound_ws_message(
+    socket: &mut WebSocket,
+    msg: Option<Result<Message, axum::Error>>,
+) -> ControlFlow<()> {
+    match msg {
+        Some(Ok(Message::Close(_))) | None => ControlFlow::Break(()),
+        Some(Ok(Message::Ping(data))) => {
+            if socket.send(Message::Pong(data)).await.is_err() {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        }
+        _ => ControlFlow::Continue(()),
+    }
+}
+
 async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
     let mut rx = state.event_bus.subscribe();
     debug!("websocket client connected to event bus");
@@ -25,36 +72,13 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
     loop {
         tokio::select! {
             event = rx.recv() => {
-                match event {
-                    Ok(coast_event) => {
-                        match serde_json::to_string(&coast_event) {
-                            Ok(json) => {
-                                if socket.send(Message::Text(json.into())).await.is_err() {
-                                    break;
-                                }
-                            }
-                            Err(e) => {
-                                warn!("failed to serialize event: {e}");
-                            }
-                        }
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                        warn!("websocket client lagged, skipped {n} events");
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                        break;
-                    }
+                if forward_event_to_socket(&mut socket, event).await.is_break() {
+                    break;
                 }
             }
             msg = socket.recv() => {
-                match msg {
-                    Some(Ok(Message::Close(_))) | None => break,
-                    Some(Ok(Message::Ping(data))) => {
-                        if socket.send(Message::Pong(data)).await.is_err() {
-                            break;
-                        }
-                    }
-                    _ => {}
+                if handle_inbound_ws_message(&mut socket, msg).await.is_break() {
+                    break;
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Extracted `forward_event_to_socket` to serialize and send bus events to the WebSocket client
- Extracted `handle_inbound_ws_message` to handle Close/Ping/Pong inbound messages
- Removed `#[allow(clippy::cognitive_complexity)]` — function now passes without suppression

## What was there before

`handle_socket` (line 20) had `#[allow(clippy::cognitive_complexity)]`. The function was ~45 lines but clippy flagged it because of deeply nested `tokio::select!` + `match` arms with 3 event-bus cases and 3 inbound-message cases.

## What changed

Single file: `coast-daemon/src/api/websocket.rs`

| Function | Type | What it does |
|---|---|---|
| `forward_event_to_socket(socket, event)` | Async | Serializes a `CoastEvent` to JSON and sends over the socket. Handles `Ok(event)`, `Lagged(n)` (warn + continue), and `Closed` (break). Returns `ControlFlow` |
| `handle_inbound_ws_message(socket, msg)` | Async | Handles inbound WS messages: `Close`/`None` → break, `Ping` → reply Pong, others → ignore. Returns `ControlFlow` |

`handle_socket` is now a thin `tokio::select!` loop calling both helpers and breaking on `ControlFlow::Break`. Signature unchanged.

## Notes

- No new unit tests added — both extracted functions take `&mut WebSocket` which cannot be constructed without a live HTTP connection. This matches the existing codebase pattern: no WS handler file in `coast-daemon/src/api/` has unit tests for socket-level functions.
- Both extracted functions are verbatim moves — no new logic introduced.
- `forward_event_to_socket` and `handle_inbound_ws_message` are reusable by other WS handlers (`ws_host_service_logs.rs`, `ws_host_service_stats.rs`, etc.) if moved to a shared module in a future PR.

## Test plan

### Verify suppression is removed
```bash
grep -n "cognitive_complexity" coast-daemon/src/api/websocket.rs
# Should return zero matches
```

### Run lint and full tests
```bash
cargo fmt --all -- --check                                  # clean
cargo clippy --workspace -- -D warnings                     # zero new warnings
cargo test -p coast-daemon                                  # 974 tests pass
cargo build --workspace                                     # clean
```

Closes #211