### PR TITLE
refactor: extract bind_dns_socket and process_one_request from dns::run_dns_server to reduce cognitive complexity

### DIFF
--- a/coast-daemon/src/dns.rs
+++ b/coast-daemon/src/dns.rs
@@ -17,46 +17,59 @@ const LOCALCOAST_SUFFIX: &str = "localcoast";
 const LOOPBACK: Ipv4Addr = Ipv4Addr::new(127, 0, 0, 1);
 const TTL: u32 = 60;
 
-/// Start the DNS server on the given port. Runs until the task is cancelled.
-#[allow(clippy::cognitive_complexity)]
-pub async fn run_dns_server(port: u16) {
+/// Bind the DNS UDP socket, returning `None` if the bind fails.
+async fn bind_dns_socket(port: u16) -> Option<UdpSocket> {
     let addr = SocketAddr::from((LOOPBACK, port));
-    let socket = match UdpSocket::bind(addr).await {
-        Ok(s) => s,
+    match UdpSocket::bind(addr).await {
+        Ok(s) => {
+            info!(
+                port,
+                "DNS server listening (resolves *.localcoast -> 127.0.0.1)"
+            );
+            Some(s)
+        }
         Err(e) => {
             warn!(
                 port,
                 "failed to bind DNS server: {e} (DNS features disabled)"
             );
+            None
+        }
+    }
+}
+
+/// Receive one DNS request, resolve it, and send the response.
+async fn process_one_request(socket: &UdpSocket, buf: &mut [u8]) {
+    let (len, src) = match socket.recv_from(buf).await {
+        Ok(r) => r,
+        Err(e) => {
+            error!("DNS recv error: {e}");
             return;
         }
     };
-    info!(
-        port,
-        "DNS server listening (resolves *.localcoast -> 127.0.0.1)"
-    );
+
+    let response = match handle_query(&buf[..len]) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            debug!("malformed DNS query from {src}: {e}");
+            return;
+        }
+    };
+
+    if let Err(e) = socket.send_to(&response, src).await {
+        debug!("DNS send error to {src}: {e}");
+    }
+}
+
+/// Start the DNS server on the given port. Runs until the task is cancelled.
+pub async fn run_dns_server(port: u16) {
+    let Some(socket) = bind_dns_socket(port).await else {
+        return;
+    };
 
     let mut buf = vec![0u8; 512];
     loop {
-        let (len, src) = match socket.recv_from(&mut buf).await {
-            Ok(r) => r,
-            Err(e) => {
-                error!("DNS recv error: {e}");
-                continue;
-            }
-        };
-
-        let response = match handle_query(&buf[..len]) {
-            Ok(bytes) => bytes,
-            Err(e) => {
-                debug!("malformed DNS query from {src}: {e}");
-                continue;
-            }
-        };
-
-        if let Err(e) = socket.send_to(&response, src).await {
-            debug!("DNS send error to {src}: {e}");
-        }
+        process_one_request(&socket, &mut buf).await;
     }
 }
 


### PR DESCRIPTION
## Summary

- Extracted `bind_dns_socket` to handle UDP socket binding with error logging
- Extracted `process_one_request` to handle one recv → parse → send cycle
- Removed `#[allow(clippy::cognitive_complexity)]` — function now passes without suppression

## What was there before

`run_dns_server` (line 21) had `#[allow(clippy::cognitive_complexity)]`. The function was ~40 lines with socket binding, then a loop containing 3 nested `match`/`if let` blocks (recv_from, handle_query, send_to) each with error logging.

## What changed

Single file: `coast-daemon/src/dns.rs`

| Function | Type | What it does |
|---|---|---|
| `bind_dns_socket(port)` | Async | Binds the UDP socket on `127.0.0.1:port`, logs success or warns on failure. Returns `Option<UdpSocket>` |
| `process_one_request(socket, buf)` | Async | Receives one DNS packet, resolves it via `handle_query`, sends the response. Logs and returns on any error |

`run_dns_server` is now: bind socket → loop { process one request }. Signature unchanged.

## Notes

- No new unit tests added — both extracted functions take `&UdpSocket` which cannot be constructed without binding a real network socket. The core DNS logic (`handle_query`, `is_localcoast_name`) already has 5 existing unit tests covering all branches (A record, subdomain, NXDOMAIN, AAAA, name matching). Both extractions are verbatim moves with no new logic introduced.

## Test plan

### Verify suppression is removed
```bash
grep -n "cognitive_complexity" coast-daemon/src/dns.rs
# Should return zero matches
```

### Run lint and full tests
```bash
cargo fmt --all -- --check                                  # clean
cargo clippy --workspace -- -D warnings                     # zero new warnings
cargo test -p coast-daemon -- dns::tests                    # 5 tests pass
cargo test --workspace                                      # all pass
cargo build --workspace                                     # clean
```

Closes #219