### PR TITLE
refactor: extract remote unassign, health check, workspace remount, and service restart from unassign::handle to reduce cognitive complexity

### DIFF
--- a/coast-daemon/src/handlers/unassign.rs
+++ b/coast-daemon/src/handlers/unassign.rs
@@ -59,12 +59,401 @@ async fn emit(tx: &tokio::sync::mpsc::Sender<BuildProgressEvent>, event: BuildPr
 
 const TOTAL_STEPS: u32 = 4;
 
+/// Handle unassign for a remote instance: reset shell workspace, sync, forward to coast-service.
+/// Reset the shell container /workspace to project root for a remote instance.
+async fn reset_remote_shell_workspace(state: &AppState, project: &str, name: &str) {
+    let shell_container = format!("{project}-coasts-{name}-shell");
+    let Some(docker) = state.docker.as_ref() else {
+        return;
+    };
+    let rt = coast_docker::dind::DindRuntime::with_client(docker.clone());
+    let mount_cmd = "umount -l /workspace 2>/dev/null; \
+        mount --bind /host-project /workspace && \
+        mount --make-rshared /workspace";
+    match rt
+        .exec_in_coast(&shell_container, &["sh", "-c", mount_cmd])
+        .await
+    {
+        Ok(r) if !r.success() => {
+            warn!(stderr = %r.stderr, "shell /workspace reset returned non-zero")
+        }
+        Err(e) => warn!(error = %e, "failed to reset shell /workspace"),
+        _ => info!("shell /workspace reset to project root"),
+    }
+}
+
+/// Sync workspace to remote and forward the unassign to coast-service.
+async fn sync_and_forward_remote_unassign(
+    state: &AppState,
+    req: &UnassignRequest,
+    project_root: &Option<std::path::PathBuf>,
+    display_branch: &Option<String>,
+) -> Result<()> {
+    let cf_data = super::assign::load_coastfile_data(&req.project);
+    let service_actions: std::collections::HashMap<String, AssignAction> = cf_data
+        .assign
+        .services
+        .keys()
+        .map(|svc| (svc.clone(), AssignAction::Hot))
+        .collect();
+
+    let remote_config =
+        super::remote::resolve_remote_for_instance(&req.project, &req.name, state).await?;
+    let client = super::remote::RemoteClient::connect(&remote_config).await?;
+
+    if let Some(ref root) = project_root {
+        let service_home = client.query_service_home().await;
+        let remote_workspace =
+            super::remote::remote_workspace_path(&service_home, &req.project, &req.name);
+        if let Err(e) = client.sync_workspace(root, &remote_workspace).await {
+            warn!(error = %e, "failed to rsync project root to remote workspace");
+        }
+    }
+
+    let assign_req = coast_core::protocol::AssignRequest {
+        name: req.name.clone(),
+        project: req.project.clone(),
+        worktree: display_branch.clone().unwrap_or_default(),
+        commit_sha: None,
+        explain: false,
+        force_sync: false,
+        service_actions,
+    };
+    let _ = super::remote::forward::forward_assign(&client, &assign_req).await;
+    Ok(())
+}
+
+async fn handle_unassign_remote(
+    req: &UnassignRequest,
+    instance: &coast_core::types::CoastInstance,
+    state: &AppState,
+    progress: &tokio::sync::mpsc::Sender<BuildProgressEvent>,
+    started_at: tokio::time::Instant,
+) -> Result<UnassignResponse> {
+    let project_root = super::assign::read_project_root(&req.project);
+    let display_branch = if let Some(ref root) = project_root {
+        read_host_branch(root).await
+    } else {
+        None
+    };
+
+    emit(
+        progress,
+        BuildProgressEvent::build_plan(vec![
+            "Validating instance".into(),
+            "Resetting workspace".into(),
+            "Syncing and notifying remote".into(),
+        ]),
+    )
+    .await;
+    emit(
+        progress,
+        BuildProgressEvent::done("Validating instance", "ok"),
+    )
+    .await;
+    emit(
+        progress,
+        BuildProgressEvent::started("Resetting workspace", 2, 3),
+    )
+    .await;
+
+    reset_remote_shell_workspace(state, &req.project, &req.name).await;
+
+    emit(
+        progress,
+        BuildProgressEvent::done("Resetting workspace", "ok"),
+    )
+    .await;
+    emit(
+        progress,
+        BuildProgressEvent::started("Syncing and notifying remote", 3, 3),
+    )
+    .await;
+
+    sync_and_forward_remote_unassign(state, req, &project_root, &display_branch).await?;
+
+    emit(
+        progress,
+        BuildProgressEvent::done("Syncing and notifying remote", "ok"),
+    )
+    .await;
+
+    let final_status = instance.status.clone();
+    {
+        let db = state.db.lock().await;
+        db.update_instance_branch(
+            &req.project,
+            &req.name,
+            display_branch.as_deref(),
+            None,
+            &final_status,
+        )?;
+        db.set_worktree(&req.project, &req.name, None)?;
+    }
+
+    state.emit_event(CoastEvent::InstanceStatusChanged {
+        name: req.name.clone(),
+        project: req.project.clone(),
+        status: final_status.as_db_str().into(),
+    });
+
+    Ok(UnassignResponse {
+        name: req.name.clone(),
+        worktree: display_branch.unwrap_or_else(|| "project root".to_string()),
+        previous_worktree: instance.worktree_name.clone(),
+        time_elapsed_ms: started_at.elapsed().as_millis() as u64,
+    })
+}
+
+/// Check inner daemon health, reverting status on failure.
+async fn check_inner_daemon_or_revert(
+    rt: &coast_docker::dind::DindRuntime,
+    container_id: &str,
+    state: &AppState,
+    project: &str,
+    name: &str,
+    prev_status: &InstanceStatus,
+) -> Result<()> {
+    let health_timeout = tokio::time::Duration::from_secs(10);
+    let health_check = rt.exec_in_coast(container_id, &["docker", "info"]);
+    match tokio::time::timeout(health_timeout, health_check).await {
+        Ok(Ok(r)) if r.success() => {
+            info!("unassign: inner daemon healthy");
+            Ok(())
+        }
+        Ok(Ok(r)) => {
+            revert_status(state, project, name, prev_status).await;
+            Err(CoastError::docker(format!(
+                "Inner Docker daemon in instance '{name}' is not healthy (exit {}). \
+                 Try `coast stop {name} && coast start {name}`.",
+                r.exit_code,
+            )))
+        }
+        Ok(Err(e)) => {
+            revert_status(state, project, name, prev_status).await;
+            Err(CoastError::docker(format!(
+                "Cannot reach inner Docker daemon in instance '{name}': {e}. \
+                 Try `coast stop {name} && coast start {name}`.",
+            )))
+        }
+        Err(_) => {
+            revert_status(state, project, name, prev_status).await;
+            Err(CoastError::docker(format!(
+                "Inner Docker daemon in instance '{name}' is unresponsive (timed out after {}s). \
+                 Try `coast rm {name} && coast run {name}`.",
+                health_timeout.as_secs(),
+            )))
+        }
+    }
+}
+
+/// Emit skip events for steps 2–4 when Docker is not available.
+async fn emit_skip_steps(progress: &tokio::sync::mpsc::Sender<BuildProgressEvent>) {
+    emit(
+        progress,
+        BuildProgressEvent::done("Checking inner daemon", "skip"),
+    )
+    .await;
+    emit(
+        progress,
+        BuildProgressEvent::done("Switching to project root", "skip"),
+    )
+    .await;
+    emit(
+        progress,
+        BuildProgressEvent::done("Restarting services", "skip"),
+    )
+    .await;
+}
+
+/// Remount /workspace back to the project root inside the container.
+async fn remount_workspace_to_project_root(
+    rt: &coast_docker::dind::DindRuntime,
+    docker: &bollard::Docker,
+    container_id: &str,
+    project: &str,
+    name: &str,
+) {
+    let cf_data = super::assign::load_coastfile_data(project);
+    let bare_svc_list = coast_core::coastfile::Coastfile::from_file(
+        &coast_core::artifact::coast_home()
+            .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".coast"))
+            .join("images")
+            .join(project)
+            .join("latest")
+            .join("coastfile.toml"),
+    )
+    .map(|cf| cf.services)
+    .unwrap_or_default();
+    crate::bare_services::stop_before_remount(docker, container_id, &bare_svc_list).await;
+    let unmount_cache =
+        coast_core::coastfile::Coastfile::build_cache_unmount_commands(&bare_svc_list);
+    let unmount_private = coast_core::coastfile::Coastfile::build_private_paths_unmount_commands(
+        &cf_data.private_paths,
+    );
+    let clear_private = coast_core::coastfile::Coastfile::build_private_paths_clear_commands(
+        &cf_data.private_paths,
+    );
+    let private_cmds = coast_core::coastfile::Coastfile::build_private_paths_mount_commands(
+        &cf_data.private_paths,
+    );
+    let cache_cmds = coast_core::coastfile::Coastfile::build_cache_mount_commands(&bare_svc_list);
+    let mount_cmd = format!(
+        "{unmount_cache}{unmount_private}{clear_private}umount -l /workspace 2>/dev/null; mount --bind /host-project /workspace && mount --make-rshared /workspace{private_cmds}{cache_cmds}"
+    );
+    match rt
+        .exec_in_coast(container_id, &["sh", "-c", &mount_cmd])
+        .await
+    {
+        Ok(r) if r.success() => info!(name = %name, "remounted /workspace to project root"),
+        Ok(r) => warn!(name = %name, stderr = %r.stderr, "failed to remount /workspace"),
+        Err(e) => warn!(name = %name, error = %e, "failed to remount /workspace"),
+    }
+}
+
+/// Run the local Docker operations for unassign: health check, remount, restart services.
+async fn run_local_unassign_docker_ops(
+    docker: &bollard::Docker,
+    container_id: &str,
+    state: &AppState,
+    req: &UnassignRequest,
+    instance: &coast_core::types::CoastInstance,
+    prev_status: &InstanceStatus,
+    progress: &tokio::sync::mpsc::Sender<BuildProgressEvent>,
+) -> Result<()> {
+    let rt = coast_docker::dind::DindRuntime::with_client(docker.clone());
+
+    check_inner_daemon_or_revert(
+        &rt,
+        container_id,
+        state,
+        &req.project,
+        &req.name,
+        prev_status,
+    )
+    .await?;
+    emit(
+        progress,
+        BuildProgressEvent::done("Checking inner daemon", "ok"),
+    )
+    .await;
+
+    // --- Remount /workspace to project root ---
+    emit(
+        progress,
+        BuildProgressEvent::started("Switching to project root", 3, TOTAL_STEPS),
+    )
+    .await;
+
+    remount_workspace_to_project_root(&rt, docker, container_id, &req.project, &req.name).await;
+
+    {
+        let db = state.db.lock().await;
+        let _ = db.set_worktree(&req.project, &req.name, None);
+    }
+    emit(
+        progress,
+        BuildProgressEvent::done("Switching to project root", "ok"),
+    )
+    .await;
+
+    // --- Restart services ---
+    emit(
+        progress,
+        BuildProgressEvent::started("Restarting services", 4, TOTAL_STEPS),
+    )
+    .await;
+    restart_services_after_unassign(
+        &rt,
+        docker,
+        container_id,
+        &req.project,
+        &req.name,
+        instance.build_id.as_deref(),
+    )
+    .await;
+    emit(
+        progress,
+        BuildProgressEvent::done("Restarting services", "ok"),
+    )
+    .await;
+
+    Ok(())
+}
+
+/// Restart compose services after workspace remount.
+async fn restart_compose_after_unassign(
+    rt: &coast_docker::dind::DindRuntime,
+    container_id: &str,
+    project: &str,
+    name: &str,
+    build_id: Option<&str>,
+) {
+    let ctx = super::compose_context_for_build(project, build_id);
+    let up_cmd = ctx.compose_shell("up -d --force-recreate --remove-orphans -t 1");
+    let up_refs: Vec<&str> = up_cmd.iter().map(std::string::String::as_str).collect();
+    match rt.exec_in_coast(container_id, &up_refs).await {
+        Ok(r) if r.success() => {
+            info!(name = %name, "compose force-recreate completed after unassign")
+        }
+        Ok(r) => warn!(name = %name, stderr = %r.stderr, "compose up after unassign had issues"),
+        Err(e) => warn!(name = %name, error = %e, "compose up after unassign failed"),
+    }
+}
+
+/// Restart bare services after workspace remount.
+async fn restart_bare_after_unassign(
+    rt: &coast_docker::dind::DindRuntime,
+    container_id: &str,
+    project: &str,
+    name: &str,
+    build_id: Option<&str>,
+) {
+    let stop_cmd = crate::bare_services::generate_stop_command();
+    let _ = rt
+        .exec_in_coast(container_id, &["sh", "-c", &stop_cmd])
+        .await;
+
+    let cf_path = super::artifact_coastfile_path(project, build_id);
+    let svc_list = coast_core::coastfile::Coastfile::from_file(&cf_path)
+        .map(|cf| cf.services)
+        .unwrap_or_default();
+
+    let start_cmd = crate::bare_services::generate_install_and_start_command(&svc_list);
+    match rt
+        .exec_in_coast(container_id, &["sh", "-c", &start_cmd])
+        .await
+    {
+        Ok(r) if r.success() => info!(name = %name, "bare services restarted after unassign"),
+        Ok(r) => {
+            warn!(name = %name, stderr = %r.stderr, stdout = %r.stdout, "bare services start after unassign had issues")
+        }
+        Err(e) => warn!(name = %name, error = %e, "bare services start after unassign failed"),
+    }
+}
+
+/// Restart compose and bare services after workspace remount.
+async fn restart_services_after_unassign(
+    rt: &coast_docker::dind::DindRuntime,
+    docker: &bollard::Docker,
+    container_id: &str,
+    project: &str,
+    name: &str,
+    build_id: Option<&str>,
+) {
+    if super::assign::has_compose(project) {
+        restart_compose_after_unassign(rt, container_id, project, name, build_id).await;
+    }
+    if crate::bare_services::has_bare_services(docker, container_id).await {
+        restart_bare_after_unassign(rt, container_id, project, name, build_id).await;
+    }
+}
+
 /// Handle an unassign request with streaming progress.
 ///
 /// Directly remounts `/workspace` back to the project root (`/host-project`)
 /// without detecting or caring about git branches. Services are restarted
 /// so their bind mounts resolve through the new mount.
-#[allow(clippy::cognitive_complexity, clippy::too_many_lines)]
 pub async fn handle(
     req: UnassignRequest,
     state: &AppState,
@@ -110,141 +499,12 @@ pub async fn handle(
         if inst.remote_host.is_some() {
             db.update_instance_status(&req.project, &req.name, &InstanceStatus::Unassigning)?;
             drop(db);
-
             state.emit_event(CoastEvent::InstanceStatusChanged {
                 name: req.name.clone(),
                 project: req.project.clone(),
                 status: "unassigning".into(),
             });
-
-            let project_root = super::assign::read_project_root(&req.project);
-            let display_branch = if let Some(ref root) = project_root {
-                read_host_branch(root).await
-            } else {
-                None
-            };
-
-            emit(
-                &progress,
-                BuildProgressEvent::build_plan(vec![
-                    "Validating instance".into(),
-                    "Resetting workspace".into(),
-                    "Syncing and notifying remote".into(),
-                ]),
-            )
-            .await;
-            emit(
-                &progress,
-                BuildProgressEvent::done("Validating instance", "ok"),
-            )
-            .await;
-            emit(
-                &progress,
-                BuildProgressEvent::started("Resetting workspace", 2, 3),
-            )
-            .await;
-
-            // Reset shell container /workspace to project root
-            let shell_container = format!("{}-coasts-{}-shell", req.project, req.name);
-            if let Some(docker) = state.docker.as_ref() {
-                let rt = coast_docker::dind::DindRuntime::with_client(docker.clone());
-                let mount_cmd = "umount -l /workspace 2>/dev/null; \
-                    mount --bind /host-project /workspace && \
-                    mount --make-rshared /workspace";
-                match rt
-                    .exec_in_coast(&shell_container, &["sh", "-c", mount_cmd])
-                    .await
-                {
-                    Ok(r) if !r.success() => {
-                        warn!(stderr = %r.stderr, "shell /workspace reset returned non-zero");
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "failed to reset shell /workspace");
-                    }
-                    _ => {
-                        info!("shell /workspace reset to project root");
-                    }
-                }
-            }
-
-            emit(
-                &progress,
-                BuildProgressEvent::done("Resetting workspace", "ok"),
-            )
-            .await;
-
-            // Forward assign to coast-service with hot actions (no service restart needed).
-            // Mutagen handles the file sync; we just need to tell coast-service the mount changed.
-            emit(
-                &progress,
-                BuildProgressEvent::started("Syncing and notifying remote", 3, 3),
-            )
-            .await;
-
-            let cf_data = super::assign::load_coastfile_data(&req.project);
-            let service_actions: std::collections::HashMap<String, AssignAction> = cf_data
-                .assign
-                .services
-                .keys()
-                .map(|svc| (svc.clone(), AssignAction::Hot))
-                .collect();
-
-            let remote_config =
-                super::remote::resolve_remote_for_instance(&req.project, &req.name, state).await?;
-            let client = super::remote::RemoteClient::connect(&remote_config).await?;
-
-            if let Some(ref root) = project_root {
-                let service_home = client.query_service_home().await;
-                let remote_workspace =
-                    super::remote::remote_workspace_path(&service_home, &req.project, &req.name);
-                if let Err(e) = client.sync_workspace(root, &remote_workspace).await {
-                    warn!(error = %e, "failed to rsync project root to remote workspace");
-                }
-            }
-
-            let assign_req = coast_core::protocol::AssignRequest {
-                name: req.name.clone(),
-                project: req.project.clone(),
-                worktree: display_branch.clone().unwrap_or_default(),
-                commit_sha: None,
-                explain: false,
-                force_sync: false,
-                service_actions,
-            };
-            let _ = super::remote::forward::forward_assign(&client, &assign_req).await;
-
-            emit(
-                &progress,
-                BuildProgressEvent::done("Syncing and notifying remote", "ok"),
-            )
-            .await;
-
-            // Final DB update: set branch to project root branch, clear worktree, restore status
-            let final_status = inst.status.clone();
-            {
-                let db = state.db.lock().await;
-                db.update_instance_branch(
-                    &req.project,
-                    &req.name,
-                    display_branch.as_deref(),
-                    None,
-                    &final_status,
-                )?;
-                db.set_worktree(&req.project, &req.name, None)?;
-            }
-
-            state.emit_event(CoastEvent::InstanceStatusChanged {
-                name: req.name.clone(),
-                project: req.project.clone(),
-                status: final_status.as_db_str().into(),
-            });
-
-            return Ok(UnassignResponse {
-                name: req.name,
-                worktree: display_branch.unwrap_or_else(|| "project root".to_string()),
-                previous_worktree: inst.worktree_name,
-                time_elapsed_ms: started_at.elapsed().as_millis() as u64,
-            });
+            return handle_unassign_remote(&req, &inst, state, &progress, started_at).await;
         }
 
         db.update_instance_status(&req.project, &req.name, &InstanceStatus::Unassigning)?;
@@ -283,205 +543,18 @@ pub async fn handle(
     .await;
 
     if let Some(docker) = state.docker.as_ref() {
-        let rt = coast_docker::dind::DindRuntime::with_client(docker.clone());
-
-        let health_timeout = tokio::time::Duration::from_secs(10);
-        let health_check = rt.exec_in_coast(&container_id, &["docker", "info"]);
-        match tokio::time::timeout(health_timeout, health_check).await {
-            Ok(Ok(r)) if r.success() => {
-                info!("unassign: inner daemon healthy");
-            }
-            Ok(Ok(r)) => {
-                revert_status(state, &req.project, &req.name, &prev_status).await;
-                return Err(CoastError::docker(format!(
-                    "Inner Docker daemon in instance '{}' is not healthy (exit {}). \
-                     Try `coast stop {} && coast start {}`.",
-                    req.name, r.exit_code, req.name, req.name,
-                )));
-            }
-            Ok(Err(e)) => {
-                revert_status(state, &req.project, &req.name, &prev_status).await;
-                return Err(CoastError::docker(format!(
-                    "Cannot reach inner Docker daemon in instance '{}': {e}. \
-                     Try `coast stop {} && coast start {}`.",
-                    req.name, req.name, req.name,
-                )));
-            }
-            Err(_) => {
-                revert_status(state, &req.project, &req.name, &prev_status).await;
-                return Err(CoastError::docker(format!(
-                    "Inner Docker daemon in instance '{}' is unresponsive (timed out after {}s). \
-                     Try `coast rm {} && coast run {}`.",
-                    req.name,
-                    health_timeout.as_secs(),
-                    req.name,
-                    req.name,
-                )));
-            }
-        }
-
-        emit(
+        run_local_unassign_docker_ops(
+            &docker,
+            &container_id,
+            state,
+            &req,
+            &instance,
+            &prev_status,
             &progress,
-            BuildProgressEvent::done("Checking inner daemon", "ok"),
         )
-        .await;
-
-        // --- Step 3: Remount /workspace to project root ---
-        emit(
-            &progress,
-            BuildProgressEvent::started("Switching to project root", 3, TOTAL_STEPS),
-        )
-        .await;
-
-        let cf_data = super::assign::load_coastfile_data(&req.project);
-        let bare_svc_list = coast_core::coastfile::Coastfile::from_file(
-            &coast_core::artifact::coast_home()
-                .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".coast"))
-                .join("images")
-                .join(&req.project)
-                .join("latest")
-                .join("coastfile.toml"),
-        )
-        .map(|cf| cf.services)
-        .unwrap_or_default();
-        crate::bare_services::stop_before_remount(&docker, &container_id, &bare_svc_list).await;
-        let unmount_cache =
-            coast_core::coastfile::Coastfile::build_cache_unmount_commands(&bare_svc_list);
-        let unmount_private =
-            coast_core::coastfile::Coastfile::build_private_paths_unmount_commands(
-                &cf_data.private_paths,
-            );
-        let clear_private = coast_core::coastfile::Coastfile::build_private_paths_clear_commands(
-            &cf_data.private_paths,
-        );
-        let private_cmds = coast_core::coastfile::Coastfile::build_private_paths_mount_commands(
-            &cf_data.private_paths,
-        );
-        let cache_cmds =
-            coast_core::coastfile::Coastfile::build_cache_mount_commands(&bare_svc_list);
-        let mount_cmd = format!(
-            "{unmount_cache}{unmount_private}{clear_private}umount -l /workspace 2>/dev/null; mount --bind /host-project /workspace && mount --make-rshared /workspace{private_cmds}{cache_cmds}"
-        );
-        let mount_result = rt
-            .exec_in_coast(&container_id, &["sh", "-c", &mount_cmd])
-            .await;
-        match &mount_result {
-            Ok(r) if r.success() => {
-                info!(name = %req.name, "remounted /workspace to project root");
-            }
-            Ok(r) => {
-                warn!(name = %req.name, stderr = %r.stderr, "failed to remount /workspace to project root");
-            }
-            Err(e) => {
-                warn!(name = %req.name, error = %e, "failed to remount /workspace to project root");
-            }
-        }
-
-        {
-            let db = state.db.lock().await;
-            let _ = db.set_worktree(&req.project, &req.name, None);
-        }
-
-        emit(
-            &progress,
-            BuildProgressEvent::done("Switching to project root", "ok"),
-        )
-        .await;
-
-        // --- Step 4: Restart services ---
-        emit(
-            &progress,
-            BuildProgressEvent::started("Restarting services", 4, TOTAL_STEPS),
-        )
-        .await;
-
-        let has_compose = super::assign::has_compose(&req.project);
-
-        if has_compose {
-            let ctx = super::compose_context_for_build(&req.project, instance.build_id.as_deref());
-            let up_cmd = ctx.compose_shell("up -d --force-recreate --remove-orphans -t 1");
-            let up_refs: Vec<&str> = up_cmd.iter().map(std::string::String::as_str).collect();
-            let up_result = rt.exec_in_coast(&container_id, &up_refs).await;
-            match &up_result {
-                Ok(r) if r.success() => {
-                    info!(name = %req.name, "compose force-recreate completed after unassign");
-                }
-                Ok(r) => {
-                    warn!(name = %req.name, stderr = %r.stderr, "compose up after unassign had issues");
-                }
-                Err(e) => {
-                    warn!(name = %req.name, error = %e, "compose up after unassign failed");
-                }
-            }
-        }
-
-        if crate::bare_services::has_bare_services(&docker, &container_id).await {
-            let stop_cmd = crate::bare_services::generate_stop_command();
-            match rt
-                .exec_in_coast(&container_id, &["sh", "-c", &stop_cmd])
-                .await
-            {
-                Ok(r) if r.success() => {
-                    info!(name = %req.name, "bare services stopped for unassign");
-                }
-                Ok(r) => {
-                    warn!(name = %req.name, stderr = %r.stderr, "bare services stop had issues");
-                }
-                Err(e) => {
-                    warn!(name = %req.name, error = %e, "bare services stop failed");
-                }
-            }
-
-            let cf_path =
-                super::artifact_coastfile_path(&req.project, instance.build_id.as_deref());
-            let svc_list = coast_core::coastfile::Coastfile::from_file(&cf_path)
-                .map(|cf| cf.services)
-                .unwrap_or_default();
-
-            let stop_cmd = crate::bare_services::generate_stop_command();
-            let _ = rt
-                .exec_in_coast(&container_id, &["sh", "-c", &stop_cmd])
-                .await;
-            let start_cmd = crate::bare_services::generate_install_and_start_command(&svc_list);
-            match rt
-                .exec_in_coast(&container_id, &["sh", "-c", &start_cmd])
-                .await
-            {
-                Ok(r) if r.success() => {
-                    info!(name = %req.name, "bare services restarted after unassign");
-                }
-                Ok(r) => {
-                    warn!(name = %req.name, stderr = %r.stderr, stdout = %r.stdout, "bare services start after unassign had issues");
-                }
-                Err(e) => {
-                    warn!(name = %req.name, error = %e, "bare services start after unassign failed");
-                }
-            }
-        }
-
-        emit(
-            &progress,
-            BuildProgressEvent::done("Restarting services", "ok"),
-        )
-        .await;
+        .await?;
     } else {
-        // No Docker client (test mode): just update DB
-        emit(
-            &progress,
-            BuildProgressEvent::done("Checking inner daemon", "skip"),
-        )
-        .await;
-        emit(
-            &progress,
-            BuildProgressEvent::done("Switching to project root", "skip"),
-        )
-        .await;
-        emit(
-            &progress,
-            BuildProgressEvent::done("Restarting services", "skip"),
-        )
-        .await;
-
+        emit_skip_steps(&progress).await;
         let db = state.db.lock().await;
         let _ = db.set_worktree(&req.project, &req.name, None);
     }
@@ -779,5 +852,28 @@ mod tests {
             err.contains("currently"),
             "error should mention 'currently': {err}"
         );
+    }
+
+    // --- reset_remote_shell_workspace tests ---
+
+    #[tokio::test]
+    async fn test_reset_remote_shell_workspace_no_docker_is_noop() {
+        let state = AppState::new_for_testing(StateDb::open_in_memory().unwrap());
+        assert!(state.docker.is_none());
+        // Should not panic with no Docker client
+        reset_remote_shell_workspace(&state, "proj", "inst").await;
+    }
+
+    // --- emit_skip_steps tests ---
+
+    #[tokio::test]
+    async fn test_emit_skip_steps_does_not_panic() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        emit_skip_steps(&tx).await;
+        let mut count = 0;
+        while rx.try_recv().is_ok() {
+            count += 1;
+        }
+        assert_eq!(count, 3, "should emit 3 skip events");
     }
 }


### PR DESCRIPTION
## Summary

- Extracted `handle_unassign_remote` for the entire remote instance flow (workspace reset, sync, forward)
- Extracted `reset_remote_shell_workspace` for resetting the shell container's /workspace mount
- Extracted `sync_and_forward_remote_unassign` for rsync + coast-service forward
- Extracted `check_inner_daemon_or_revert` for timed health check with status revert on failure
- Extracted `remount_workspace_to_project_root` for the mount command construction + execution
- Extracted `restart_services_after_unassign` orchestrating compose + bare restart
- Extracted `restart_compose_after_unassign` and `restart_bare_after_unassign` for individual service type restarts
- Extracted `run_local_unassign_docker_ops` for the full local Docker operations sequence
- Extracted `emit_skip_steps` for Docker-unavailable progress events
- Removed `#[allow(clippy::cognitive_complexity, clippy::too_many_lines)]` — function now passes without suppression
- Added 2 unit tests for new helpers

## What was there before

`handle` (line 67) had `#[allow(clippy::cognitive_complexity, clippy::too_many_lines)]`. The function was ~470 lines with two completely separate execution paths (remote vs local) crammed into one function, plus workspace remounting, inner daemon health check with status revert, and service restart logic with compose + bare branches.

## What changed

Single file: `coast-daemon/src/handlers/unassign.rs`

| Function | Type | What it does |
|---|---|---|
| `handle_unassign_remote(...)` | Async | Full remote unassign: reset shell workspace, sync, forward to coast-service, update DB |
| `reset_remote_shell_workspace(state, project, name)` | Async | Resets shell container /workspace to project root via bind mount |
| `sync_and_forward_remote_unassign(state, req, root, branch)` | Async | Rsyncs project root to remote, forwards assign with hot actions |
| `check_inner_daemon_or_revert(rt, cid, state, project, name, prev)` | Async | Timed `docker info` check, reverts status on any failure mode |
| `remount_workspace_to_project_root(rt, docker, cid, project, name)` | Async | Stops bare services, builds unmount/mount/cache commands, executes remount |
| `restart_compose_after_unassign(...)` | Async | Runs `compose up -d --force-recreate` |
| `restart_bare_after_unassign(...)` | Async | Stops and reinstalls bare services |
| `restart_services_after_unassign(...)` | Async | Orchestrates compose + bare restart |
| `run_local_unassign_docker_ops(...)` | Async | Full local sequence: health check → remount → restart |
| `emit_skip_steps(progress)` | Async | Emits 3 skip events when Docker unavailable |

`handle` is now: validate → remote branch or local branch → final DB update → emit event. Signature unchanged.

## New tests (2)

- `test_reset_remote_shell_workspace_no_docker_is_noop` — no Docker → no panic
- `test_emit_skip_steps_does_not_panic` — emits exactly 3 skip events

## Test plan

### Run all tests
```bash
cargo fmt --all -- --check                                      # clean
cargo clippy --workspace -- -D warnings                         # zero new warnings
cargo test -p coast-daemon -- handlers::unassign::tests         # 17 pass (15 existing + 2 new)
cargo test -p coast-daemon                                      # 976 pass, 0 fail
cargo test --workspace                                          # 0 failures
cargo build --workspace                                         # clean
```

### Verify suppression is removed
```bash
grep -n "cognitive_complexity\|too_many_lines" coast-daemon/src/handlers/unassign.rs
# Should return zero matches
```

Closes #209