### PR TITLE
refactor: extract log command resolution, exec creation, and stream helpers from ws_logs::handle_logs_socket to reduce cognitive complexity

### DIFF
--- a/coast-daemon/src/api/ws_logs.rs
+++ b/coast-daemon/src/api/ws_logs.rs
@@ -89,7 +89,149 @@ async fn ws_handler(
     Ok(ws.on_upgrade(move |socket| handle_logs_socket(socket, state, container_id, params)))
 }
 
-#[allow(clippy::cognitive_complexity)]
+/// Build compose log shell command with optional service filter.
+fn build_compose_log_cmd(project: &str, service: Option<&str>) -> Vec<String> {
+    let ctx = compose_context(project);
+    let mut subcmd = "logs --tail 200 --follow".to_string();
+    if let Some(svc) = service {
+        subcmd.push(' ');
+        subcmd.push_str(svc);
+    }
+    ctx.compose_shell(&subcmd)
+}
+
+/// Build bare log shell command with optional service filter.
+fn build_bare_log_cmd(service: Option<&str>) -> Vec<String> {
+    let tail_cmd = crate::bare_services::generate_logs_command(service, None, false, true);
+    vec!["sh".to_string(), "-c".to_string(), tail_cmd]
+}
+
+/// Build merged bare + compose log command for parallel streaming.
+fn build_mixed_merged_log_cmd(project: &str) -> Vec<String> {
+    let bare_cmd = crate::bare_services::generate_logs_command(None, None, false, true);
+    let compose_script = compose_context(project).compose_script("logs --tail 200 --follow");
+    vec![
+        "sh".to_string(),
+        "-c".to_string(),
+        format!("({bare_cmd}) & ({compose_script}) & wait"),
+    ]
+}
+
+/// Resolve the log streaming command based on bare/compose availability and service filter.
+async fn resolve_stream_log_command(
+    docker: &bollard::Docker,
+    container_id: &str,
+    project: &str,
+    service: Option<&str>,
+    has_bare: bool,
+    has_compose: bool,
+) -> Vec<String> {
+    if has_bare && has_compose && service.is_none() {
+        return build_mixed_merged_log_cmd(project);
+    }
+    if has_bare && has_compose {
+        let svc = service.unwrap();
+        let runtime = coast_docker::dind::DindRuntime::with_client(docker.clone());
+        let log_path = format!("{}/{}.log", crate::bare_services::LOG_DIR, svc);
+        let is_bare_svc = runtime
+            .exec_in_coast(container_id, &["test", "-f", &log_path])
+            .await
+            .map(|r| r.success())
+            .unwrap_or(false);
+        return if is_bare_svc {
+            build_bare_log_cmd(Some(svc))
+        } else {
+            compose_context(project).compose_shell(&format!("logs --tail 200 --follow {svc}"))
+        };
+    }
+    if has_bare {
+        return build_bare_log_cmd(service);
+    }
+    build_compose_log_cmd(project, service)
+}
+
+/// Forward a log chunk from the exec stream to the WebSocket.
+async fn forward_log_chunk(
+    socket: &mut WebSocket,
+    chunk: Option<Result<bollard::container::LogOutput, bollard::errors::Error>>,
+) -> std::ops::ControlFlow<()> {
+    match chunk {
+        Some(Ok(msg)) => {
+            let text = match msg {
+                bollard::container::LogOutput::StdOut { message }
+                | bollard::container::LogOutput::StdErr { message } => {
+                    String::from_utf8_lossy(&message).to_string()
+                }
+                _ => return std::ops::ControlFlow::Continue(()),
+            };
+            if socket.send(Message::Text(text.into())).await.is_err() {
+                std::ops::ControlFlow::Break(())
+            } else {
+                std::ops::ControlFlow::Continue(())
+            }
+        }
+        Some(Err(e)) => {
+            warn!(error = %e, "log stream error");
+            std::ops::ControlFlow::Break(())
+        }
+        None => std::ops::ControlFlow::Break(()),
+    }
+}
+
+/// Handle an inbound WebSocket Close message.
+fn handle_inbound_close(msg: &Option<Result<Message, axum::Error>>) -> std::ops::ControlFlow<()> {
+    match msg {
+        Some(Ok(Message::Close(_))) | None => std::ops::ControlFlow::Break(()),
+        _ => std::ops::ControlFlow::Continue(()),
+    }
+}
+
+/// Create and start an exec attached to stdout/stderr, sending errors over the socket.
+async fn create_and_start_log_exec(
+    docker: &bollard::Docker,
+    container_id: &str,
+    cmd_parts: &[String],
+    socket: &mut WebSocket,
+) -> Option<StartExecResults> {
+    let cmd_refs: Vec<&str> = cmd_parts.iter().map(std::string::String::as_str).collect();
+    let exec_options = CreateExecOptions {
+        cmd: Some(
+            cmd_refs
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
+        ),
+        attach_stdout: Some(true),
+        attach_stderr: Some(true),
+        ..Default::default()
+    };
+
+    let exec = match docker.create_exec(container_id, exec_options).await {
+        Ok(e) => e,
+        Err(e) => {
+            let _ = socket
+                .send(Message::Text(format!("Failed to create exec: {e}").into()))
+                .await;
+            return None;
+        }
+    };
+
+    let start_options = StartExecOptions {
+        detach: false,
+        ..Default::default()
+    };
+
+    match docker.start_exec(&exec.id, Some(start_options)).await {
+        Ok(o) => Some(o),
+        Err(e) => {
+            let _ = socket
+                .send(Message::Text(format!("Failed to start exec: {e}").into()))
+                .await;
+            None
+        }
+    }
+}
+
 async fn handle_logs_socket(
     mut socket: WebSocket,
     state: Arc<AppState>,
@@ -117,118 +259,33 @@ async fn handle_logs_socket(
     let has_bare = crate::bare_services::has_bare_services(&docker, &container_id).await;
     let has_compose = crate::handlers::assign::has_compose(&params.project);
 
-    let cmd_parts = if has_bare && has_compose && params.service.is_none() {
-        // Mixed mode, no service filter: merge both log streams in parallel
-        let bare_cmd = crate::bare_services::generate_logs_command(None, None, false, true);
-        let compose_script =
-            compose_context(&params.project).compose_script("logs --tail 200 --follow");
-        vec![
-            "sh".to_string(),
-            "-c".to_string(),
-            format!("({bare_cmd}) & ({compose_script}) & wait"),
-        ]
-    } else if has_bare && has_compose {
-        // Mixed mode with a service filter: route to the right log source
-        let service = params.service.as_deref().unwrap();
-        let runtime = coast_docker::dind::DindRuntime::with_client(docker.clone());
-        let log_path = format!("{}/{}.log", crate::bare_services::LOG_DIR, service);
-        let is_bare_svc = runtime
-            .exec_in_coast(&container_id, &["test", "-f", &log_path])
-            .await
-            .map(|r| r.success())
-            .unwrap_or(false);
-        if is_bare_svc {
-            let tail_cmd =
-                crate::bare_services::generate_logs_command(Some(service), None, false, true);
-            vec!["sh".to_string(), "-c".to_string(), tail_cmd]
-        } else {
-            let ctx = compose_context(&params.project);
-            ctx.compose_shell(&format!("logs --tail 200 --follow {service}"))
-        }
-    } else if has_bare {
-        let tail_cmd = crate::bare_services::generate_logs_command(
-            params.service.as_deref(),
-            None,
-            false,
-            true,
-        );
-        vec!["sh".to_string(), "-c".to_string(), tail_cmd]
-    } else {
-        let ctx = compose_context(&params.project);
-        let mut subcmd = "logs --tail 200 --follow".to_string();
-        if let Some(ref svc) = params.service {
-            subcmd.push(' ');
-            subcmd.push_str(svc);
-        }
-        ctx.compose_shell(&subcmd)
-    };
-    let cmd_refs: Vec<&str> = cmd_parts.iter().map(std::string::String::as_str).collect();
+    let cmd_parts = resolve_stream_log_command(
+        &docker,
+        &container_id,
+        &params.project,
+        params.service.as_deref(),
+        has_bare,
+        has_compose,
+    )
+    .await;
 
-    let exec_options = CreateExecOptions {
-        cmd: Some(
-            cmd_refs
-                .iter()
-                .map(std::string::ToString::to_string)
-                .collect(),
-        ),
-        attach_stdout: Some(true),
-        attach_stderr: Some(true),
-        ..Default::default()
-    };
-
-    let exec = match docker.create_exec(&container_id, exec_options).await {
-        Ok(e) => e,
-        Err(e) => {
-            let _ = socket
-                .send(Message::Text(format!("Failed to create exec: {e}").into()))
-                .await;
-            return;
-        }
-    };
-
-    let start_options = StartExecOptions {
-        detach: false,
-        ..Default::default()
-    };
-
-    let output = match docker.start_exec(&exec.id, Some(start_options)).await {
-        Ok(o) => o,
-        Err(e) => {
-            let _ = socket
-                .send(Message::Text(format!("Failed to start exec: {e}").into()))
-                .await;
-            return;
-        }
+    let Some(output) =
+        create_and_start_log_exec(&docker, &container_id, &cmd_parts, &mut socket).await
+    else {
+        return;
     };
 
     if let StartExecResults::Attached { mut output, .. } = output {
         loop {
             tokio::select! {
                 chunk = output.next() => {
-                    match chunk {
-                        Some(Ok(msg)) => {
-                            let text = match msg {
-                                bollard::container::LogOutput::StdOut { message } |
-                                bollard::container::LogOutput::StdErr { message } => {
-                                    String::from_utf8_lossy(&message).to_string()
-                                }
-                                _ => continue,
-                            };
-                            if socket.send(Message::Text(text.into())).await.is_err() {
-                                break;
-                            }
-                        }
-                        Some(Err(e)) => {
-                            warn!(error = %e, "log stream error");
-                            break;
-                        }
-                        None => break,
+                    if forward_log_chunk(&mut socket, chunk).await.is_break() {
+                        break;
                     }
                 }
                 msg = socket.recv() => {
-                    match msg {
-                        Some(Ok(Message::Close(_))) | None => break,
-                        _ => {}
+                    if handle_inbound_close(&msg).is_break() {
+                        break;
                     }
                 }
             }
@@ -348,4 +405,42 @@ async fn handle_remote_logs_socket(
         name = %params.name,
         "remote logs stream websocket disconnected"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_bare_log_cmd_no_service() {
+        let cmd = build_bare_log_cmd(None);
+        assert_eq!(cmd[0], "sh");
+        assert_eq!(cmd[1], "-c");
+        assert!(cmd.len() >= 3);
+    }
+
+    #[test]
+    fn test_build_bare_log_cmd_with_service() {
+        let cmd = build_bare_log_cmd(Some("web"));
+        assert_eq!(cmd[0], "sh");
+        assert_eq!(cmd[1], "-c");
+        assert!(cmd[2].contains("web"));
+    }
+
+    #[test]
+    fn test_handle_inbound_close_on_close_message() {
+        let msg = Some(Ok(Message::Close(None)));
+        assert!(handle_inbound_close(&msg).is_break());
+    }
+
+    #[test]
+    fn test_handle_inbound_close_on_none() {
+        assert!(handle_inbound_close(&None).is_break());
+    }
+
+    #[test]
+    fn test_handle_inbound_close_on_text_continues() {
+        let msg = Some(Ok(Message::Text("hello".into())));
+        assert!(handle_inbound_close(&msg).is_continue());
+    }
 }


### PR DESCRIPTION
## Summary

- Extracted `build_compose_log_cmd`, `build_bare_log_cmd`, `build_mixed_merged_log_cmd` for log command construction
- Extracted `resolve_stream_log_command` to orchestrate the 4-way bare/compose/service routing
- Extracted `create_and_start_log_exec` for Docker exec creation + start with error handling
- Extracted `forward_log_chunk` for log stream chunk forwarding via ControlFlow
- Extracted `handle_inbound_close` for WebSocket Close handling (pure sync, testable)
- Removed `#[allow(clippy::cognitive_complexity)]` — function now passes without suppression
- Added 5 unit tests

## What was there before

`handle_logs_socket` (line 92) had `#[allow(clippy::cognitive_complexity)]`. The function was ~150 lines with 4-way command construction branching (mixed-no-filter, mixed-with-filter, bare-only, compose-only), exec create/start error handling, and a tokio::select! streaming loop.

## What changed

Single file: `coast-daemon/src/api/ws_logs.rs`

| Function | Type | What it does |
|---|---|---|
| `build_compose_log_cmd(project, service)` | Sync | Builds compose log command with optional service |
| `build_bare_log_cmd(service)` | Sync | Builds bare tail command |
| `build_mixed_merged_log_cmd(project)` | Sync | Builds merged parallel bare+compose command |
| `resolve_stream_log_command(...)` | Async | Routes to correct command builder based on bare/compose/service |
| `create_and_start_log_exec(docker, cid, cmd, socket)` | Async | Creates + starts exec, sends error over socket on failure |
| `forward_log_chunk(socket, chunk)` | Async | StdOut/StdErr -> send text, returns ControlFlow |
| `handle_inbound_close(msg)` | Pure, sync | Close/None -> Break, others -> Continue |

handle_logs_socket is now: Docker check -> resolve command -> create exec -> stream loop. Signature unchanged.

## New tests (5)

- test_build_bare_log_cmd_no_service - bare cmd without filter
- test_build_bare_log_cmd_with_service - bare cmd includes service
- test_handle_inbound_close_on_close_message - Close -> Break
- test_handle_inbound_close_on_none - None -> Break
- test_handle_inbound_close_on_text_continues - Text -> Continue

## Test plan

cargo fmt --all -- --check (clean), cargo clippy --workspace -- -D warnings (zero), cargo test -p coast-daemon -- api::ws_logs::tests (5 pass), cargo test -p coast-daemon (979 pass), cargo test --workspace (0 failures), cargo build --workspace (clean)

Closes #212