### PR TITLE
Fix restart-services with autostart=false bare services

### DIFF
--- a/coast-daemon/src/handlers/restart_services.rs
+++ b/coast-daemon/src/handlers/restart_services.rs
@@ -17,10 +17,20 @@ use tracing::info;
 use coast_core::error::{CoastError, Result};
 use coast_core::protocol::{RestartServicesRequest, RestartServicesResponse};
 use coast_core::types::InstanceStatus;
-use coast_docker::runtime::Runtime;
+use coast_docker::runtime::{ExecResult, Runtime};
 
 use crate::handlers::compose_context_for_build;
 use crate::server::AppState;
+
+trait RestartRuntime: Send + Sync {
+    async fn exec_restart(&self, container_id: &str, cmd: &[&str]) -> Result<ExecResult>;
+}
+
+impl RestartRuntime for coast_docker::dind::DindRuntime {
+    async fn exec_restart(&self, container_id: &str, cmd: &[&str]) -> Result<ExecResult> {
+        Runtime::exec_in_coast(self, container_id, cmd).await
+    }
+}
 
 /// Read coastfile flags to determine which service types exist and whether autostart is enabled.
 fn read_coastfile_flags(coastfile_path: &std::path::Path) -> (bool, bool, bool) {
@@ -44,13 +54,13 @@ fn read_coastfile_flags(coastfile_path: &std::path::Path) -> (bool, bool, bool) 
 
 /// Execute a command inside a container with consistent error handling.
 async fn exec_dind_step(
-    rt: &coast_docker::dind::DindRuntime,
+    rt: &impl RestartRuntime,
     container_id: &str,
     cmd: &[&str],
     step_name: &str,
     instance_name: &str,
 ) -> Result<()> {
-    let result = rt.exec_in_coast(container_id, cmd).await.map_err(|e| {
+    let result = rt.exec_restart(container_id, cmd).await.map_err(|e| {
         CoastError::docker(format!(
             "Failed to exec {step_name} in instance '{instance_name}': {e}"
         ))
@@ -62,6 +72,41 @@ async fn exec_dind_step(
         )));
     }
     Ok(())
+}
+
+async fn bare_stop_script_exists(rt: &impl RestartRuntime, container_id: &str) -> bool {
+    rt.exec_restart(
+        container_id,
+        &["test", "-f", "/coast-supervisor/stop-all.sh"],
+    )
+    .await
+    .map(|r| r.success())
+    .unwrap_or(false)
+}
+
+async fn ensure_bare_stop_script_exists(
+    rt: &impl RestartRuntime,
+    container_id: &str,
+    autostart: bool,
+    instance_name: &str,
+) -> Result<bool> {
+    if bare_stop_script_exists(rt, container_id).await {
+        return Ok(true);
+    }
+
+    if !autostart {
+        info!(
+            "autostart=false and no bare service supervisor initialized, skipping bare service restart"
+        );
+        return Ok(false);
+    }
+
+    Err(CoastError::docker(format!(
+        "Bare services are configured for instance '{instance_name}', \
+         but /coast-supervisor/stop-all.sh is missing. \
+         Try `coast stop {instance_name} && coast start {instance_name}`, \
+         or recreate it with `coast rm {instance_name} && coast run {instance_name}`."
+    )))
 }
 
 /// Discover the compose project name and build the base `docker compose` args.
@@ -178,11 +223,15 @@ async fn restart_compose_services(
 
 /// Restart bare services: stop-all.sh, then optionally start-all.sh.
 async fn restart_bare_services(
-    rt: &coast_docker::dind::DindRuntime,
+    rt: &impl RestartRuntime,
     container_id: &str,
     autostart: bool,
     instance_name: &str,
 ) -> Result<Option<String>> {
+    if !ensure_bare_stop_script_exists(rt, container_id, autostart, instance_name).await? {
+        return Ok(None);
+    }
+
     exec_dind_step(
         rt,
         container_id,
@@ -454,5 +503,137 @@ mod tests {
         assert!(has_compose);
         assert!(!has_services);
         assert!(autostart);
+    }
+
+    struct MockRestartRuntime {
+        results: std::sync::Mutex<std::collections::VecDeque<Result<ExecResult>>>,
+        commands: std::sync::Mutex<Vec<Vec<String>>>,
+    }
+
+    impl MockRestartRuntime {
+        fn new(results: Vec<Result<ExecResult>>) -> Self {
+            Self {
+                results: std::sync::Mutex::new(results.into()),
+                commands: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn commands(&self) -> Vec<Vec<String>> {
+            self.commands.lock().unwrap().clone()
+        }
+    }
+
+    impl RestartRuntime for MockRestartRuntime {
+        async fn exec_restart(&self, _container_id: &str, cmd: &[&str]) -> Result<ExecResult> {
+            self.commands
+                .lock()
+                .unwrap()
+                .push(cmd.iter().map(|part| (*part).to_string()).collect());
+            self.results.lock().unwrap().pop_front().unwrap_or_else(|| {
+                Ok(ExecResult {
+                    exit_code: 0,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
+            })
+        }
+    }
+
+    fn exec_result(exit_code: i64) -> ExecResult {
+        ExecResult {
+            exit_code,
+            stdout: String::new(),
+            stderr: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_restart_bare_services_autostart_false_without_supervisor_is_noop() {
+        let runtime = MockRestartRuntime::new(vec![Ok(exec_result(1))]);
+
+        let result = restart_bare_services(&runtime, "container-123", false, "dev-1")
+            .await
+            .unwrap();
+
+        assert_eq!(result, None);
+        assert_eq!(
+            runtime.commands(),
+            vec![vec![
+                "test".to_string(),
+                "-f".to_string(),
+                "/coast-supervisor/stop-all.sh".to_string()
+            ]]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_restart_bare_services_autostart_true_without_supervisor_errors() {
+        let runtime = MockRestartRuntime::new(vec![Ok(exec_result(1))]);
+
+        let err = restart_bare_services(&runtime, "container-123", true, "dev-1")
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("/coast-supervisor/stop-all.sh is missing"));
+        assert_eq!(runtime.commands().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_restart_bare_services_autostart_false_with_supervisor_stops_only() {
+        let runtime = MockRestartRuntime::new(vec![Ok(exec_result(0)), Ok(exec_result(0))]);
+
+        let result = restart_bare_services(&runtime, "container-123", false, "dev-1")
+            .await
+            .unwrap();
+
+        assert_eq!(result, None);
+        assert_eq!(
+            runtime.commands(),
+            vec![
+                vec![
+                    "test".to_string(),
+                    "-f".to_string(),
+                    "/coast-supervisor/stop-all.sh".to_string()
+                ],
+                vec![
+                    "sh".to_string(),
+                    "/coast-supervisor/stop-all.sh".to_string()
+                ]
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_restart_bare_services_autostart_true_with_supervisor_restarts() {
+        let runtime = MockRestartRuntime::new(vec![
+            Ok(exec_result(0)),
+            Ok(exec_result(0)),
+            Ok(exec_result(0)),
+        ]);
+
+        let result = restart_bare_services(&runtime, "container-123", true, "dev-1")
+            .await
+            .unwrap();
+
+        assert_eq!(result, Some("(all bare services)".to_string()));
+        assert_eq!(
+            runtime.commands(),
+            vec![
+                vec![
+                    "test".to_string(),
+                    "-f".to_string(),
+                    "/coast-supervisor/stop-all.sh".to_string()
+                ],
+                vec![
+                    "sh".to_string(),
+                    "/coast-supervisor/stop-all.sh".to_string()
+                ],
+                vec![
+                    "sh".to_string(),
+                    "/coast-supervisor/start-all.sh".to_string()
+                ]
+            ]
+        );
     }
 }

--- a/dindind/integration.yaml
+++ b/dindind/integration.yaml
@@ -125,6 +125,10 @@ tests:
     script: integrated-examples/test_restart_services.sh
     status: pass
     cached_seconds: 176
+  test_restart_services_bare_noautostart:
+    script: integrated-examples/test_restart_services_bare_noautostart.sh
+    timeout: 300
+    note: "PR #254 regression: coast restart-services on a Running instance whose [services.*] supervisor was never initialized because of autostart=false must be a tolerated no-op, not an error"
   test_nuke:
     script: integrated-examples/test_nuke.sh
     status: pass

--- a/integrated-examples/setup.sh
+++ b/integrated-examples/setup.sh
@@ -1363,6 +1363,69 @@ setup_coast_noautostart() {
 
 setup_coast_noautostart
 
+# --- coast-bare-noautostart ---
+# Bare-services project with autostart = false. Regression fixture
+# for PR #254: when [services.*] is combined with autostart=false,
+# `coast run` skips writing the supervisor scripts. The fix makes
+# `coast restart-services` tolerate the missing scripts on a Running
+# instance instead of erroring on `sh /coast-supervisor/stop-all.sh`.
+
+setup_coast_bare_noautostart() {
+    local dir="$PROJECTS_DIR/coast-bare-noautostart"
+    echo "Setting up coast-bare-noautostart..."
+    mkdir -p "$dir"
+
+    rm -rf "$dir/.git" "$dir/.coasts"
+
+    cat > "$dir/Coastfile" << 'COASTFILE_EOF'
+# coast-bare-noautostart: regression fixture for PR #254.
+#
+# Combines [services.*] with autostart = false. `coast run` will
+# skip the bare-service supervisor setup because of autostart=false,
+# so /coast-supervisor/start-all.sh and stop-all.sh never get written.
+# `coast restart-services` (after `coast start`) must tolerate the
+# missing scripts and treat the bare-service restart as a no-op.
+
+[coast]
+name = "coast-bare-noautostart"
+runtime = "dind"
+autostart = false
+
+[coast.setup]
+packages = ["nodejs", "npm"]
+
+[services.web]
+command = "node server.js"
+port = 40050
+restart = "on-failure"
+
+[ports]
+web = 40050
+COASTFILE_EOF
+
+    cat > "$dir/server.js" << 'SERVERJS_EOF'
+const http = require("http");
+const PORT = process.env.PORT || 40050;
+http.createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ message: "noautostart bare service" }));
+}).listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});
+SERVERJS_EOF
+
+    cd "$dir"
+    git init -b main
+    git config user.name "Coast Dev"
+    git config user.email "dev@coasts.dev"
+    git add -A
+    git commit -m "initial commit: bare services with autostart=false"
+
+    echo "  coast-bare-noautostart ready"
+}
+
+setup_coast_bare_noautostart
+
 # --- coast-private-paths ---
 # Tests per-instance filesystem isolation via private_paths.
 # No git repo needed, no compose, no services — just a DinD container

--- a/integrated-examples/test_restart_services_bare_noautostart.sh
+++ b/integrated-examples/test_restart_services_bare_noautostart.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# Regression test for PR #254 (Fix restart-services with autostart=false bare services).
+#
+# Background:
+#   `coast run` short-circuits bare-service setup when the Coastfile has
+#   `autostart = false`, so `/coast-supervisor/start-all.sh` and
+#   `/coast-supervisor/stop-all.sh` are never written. After a subsequent
+#   `coast start` flips the instance to Running, `coast restart-services`
+#   re-parses the cached Coastfile, sees `[services.*]`, and used to
+#   unconditionally execute the missing `stop-all.sh` — failing with
+#   `sh: /coast-supervisor/stop-all.sh: No such file or directory`.
+#
+#   PR #254 makes restart-services tolerate the missing supervisor on
+#   `autostart=false` instances (clean no-op) and surface a clearer error
+#   on `autostart=true` instances whose supervisor is unexpectedly absent.
+#
+# This test exercises the exact bug repro that the PR's Rust unit tests
+# only cover via a mock runtime. It would FAIL on `main` and PASS on
+# pr-254.
+#
+# Prerequisites:
+#   - Docker running
+#   - socat installed
+#   - Coast binaries built (cargo build --release)
+#
+# Usage:
+#   ./integrated-examples/test_restart_services_bare_noautostart.sh
+
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/helpers.sh"
+
+register_cleanup
+
+# --- Preflight ---
+
+preflight_checks
+
+# --- Setup ---
+
+echo ""
+echo "=== Setup ==="
+
+clean_slate
+
+"$HELPERS_DIR/setup.sh"
+pass "Examples initialized"
+
+start_daemon
+
+# ============================================================
+# Test: bare services + autostart=false, then start, then restart-services
+# ============================================================
+
+echo ""
+echo "=== Test: restart-services on Running instance with bare services + autostart=false ==="
+
+cd "$PROJECTS_DIR/coast-bare-noautostart"
+
+BUILD_OUTPUT=$($COAST build 2>&1) || { echo "$BUILD_OUTPUT"; fail "coast build failed for coast-bare-noautostart"; }
+pass "coast-bare-noautostart build succeeded"
+
+# Phase 1: coast run with autostart=false leaves the instance Idle and
+# does NOT write supervisor scripts (run/mod.rs:resolve_coastfile_flags
+# returns has_services=false when autostart=false is set).
+RUN_OUTPUT=$($COAST run rs-bare-noauto 2>&1) || { echo "$RUN_OUTPUT"; fail "coast run failed for coast-bare-noautostart"; }
+CLEANUP_INSTANCES+=("rs-bare-noauto")
+pass "coast run rs-bare-noauto succeeded"
+
+LS_AFTER_RUN=$($COAST ls 2>&1)
+assert_contains "$LS_AFTER_RUN" "rs-bare-noauto" "instance is listed"
+assert_contains "$LS_AFTER_RUN" "idle" "instance is idle (autostart=false)"
+
+# Phase 2: coast start flips the container to Running. start.rs
+# calls start_bare_services_if_present, which is best-effort: if
+# /coast-supervisor doesn't exist it returns false and does nothing
+# (no error). The instance status still becomes Running.
+START_OUTPUT=$($COAST start rs-bare-noauto 2>&1) || { echo "$START_OUTPUT"; fail "coast start failed"; }
+pass "coast start rs-bare-noauto succeeded"
+
+sleep 5
+
+LS_AFTER_START=$($COAST ls 2>&1)
+assert_contains "$LS_AFTER_START" "running" "instance is running after coast start"
+
+# Phase 3: confirm the supervisor stop script genuinely doesn't exist.
+# This is the precondition that makes this test meaningful — without
+# it, the assertions below would not exercise the bug fix.
+EXEC_OUT=$($COAST exec rs-bare-noauto -- sh -c "test -f /coast-supervisor/stop-all.sh && echo PRESENT || echo MISSING" 2>&1)
+assert_contains "$EXEC_OUT" "MISSING" "/coast-supervisor/stop-all.sh was never written by coast run"
+
+# Phase 4: THE TEST. On `main` this errors with
+#   "stop-all.sh failed in instance 'rs-bare-noauto': sh: /coast-supervisor/stop-all.sh: No such file or directory"
+# On pr-254 this is a clean no-op: ensure_bare_stop_script_exists()
+# sees the missing file and autostart=false, returns Ok(false), and
+# restart_bare_services returns Ok(None).
+RESTART_OUTPUT=$($COAST restart-services rs-bare-noauto 2>&1) || {
+    echo "----- restart-services output -----"
+    echo "$RESTART_OUTPUT"
+    echo "------------------------------------"
+    fail "restart-services errored on Running instance with bare+autostart=false (PR #254 regression)"
+}
+pass "coast restart-services rs-bare-noauto succeeded (PR #254 fix is in effect)"
+
+assert_contains "$RESTART_OUTPUT" "ok" "restart-services returned ok"
+assert_not_contains "$RESTART_OUTPUT" "(all bare services)" "no bare services were restarted (autostart=false no-op)"
+assert_not_contains "$RESTART_OUTPUT" "stop-all.sh" "no reference to stop-all.sh in successful output"
+
+# Phase 5: instance must remain Running afterward.
+LS_AFTER_RESTART=$($COAST ls 2>&1)
+assert_contains "$LS_AFTER_RESTART" "running" "instance is still running after restart-services no-op"
+
+echo ""
+echo "=== restart-services bare+autostart=false regression test passed ==="


### PR DESCRIPTION
## Summary
- avoid running `/coast-supervisor/stop-all.sh` when bare services are configured but an `autostart = false` instance never initialized the supervisor scripts
- keep existing behavior for initialized bare supervisors: stop-only when autostart is false, stop/start when autostart is true
- return a clearer error for autostart-enabled instances whose bare-service supervisor is unexpectedly missing
- add targeted regression coverage for the missing-supervisor and initialized-supervisor paths

## Root cause
`coast run` skips bare service startup when the Coastfile has `autostart = false`, so `/coast-supervisor/start-all.sh` and `/coast-supervisor/stop-all.sh` are never generated. `coast restart-services` reparses the cached Coastfile, sees `[services.*]`, and unconditionally executed the missing stop script.

## Validation
- `cargo fmt --check`
- `COAST_SKIP_UI_BUILD=1 cargo test -p coast-daemon restart_services --lib`
- `COAST_SKIP_UI_BUILD=1 cargo test -p coast-daemon bare_services --lib`
- `COAST_SKIP_UI_BUILD=1 cargo clippy -p coast-daemon --lib --tests -- -D warnings` still fails on pre-existing repo-wide lints outside this patch; no remaining `restart_services.rs` lint after refactor.